### PR TITLE
feat: Implement Phase 2 - AI Integration for MSA Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,196 @@
-# msa
-A versatile NPM monorepo framework designed as a foundational agent for building diverse service architectures. MSA provides developers with a plugin-based approach to construct flexible microservices that adapt to real-world application requirements.
+# MSA - Generic and Flexible Microservice Agent Framework
+
+A versatile TypeScript NPM monorepo framework designed as a foundational agent for building diverse service architectures with integrated LLM capabilities. MSA provides developers with a plugin-based approach to construct flexible microservices that adapt to real-world application requirements, powered by AI-driven interactions and protocol support.
+
+## Overview
+
+MSA serves as a TypeScript-based core foundation that becomes whatever service type you need through its plugin architecture. By injecting one or more specialized plugin packages into the lightweight core, developers can rapidly build and deploy various service patterns without being locked into a specific transport layer or communication protocol.
+
+**Enhanced with LLM Integration** - Built-in Langchain integration enables AI-powered services, intelligent agents, and protocol-aware communication systems for modern AI-driven applications.
+
+## Packages
+
+This monorepo contains the following packages:
+
+| Package | Description |
+|---------|-------------|
+| [@arifwidianto/msa-core](packages/core) | Core foundation with essential interfaces and base functionality |
+| [@arifwidianto/msa-plugin-http](packages/plugin-http) | HTTP server plugin using Express.js |
+| [@arifwidianto/msa-plugin-websocket](packages/plugin-websocket) | WebSocket server plugin using ws |
+| [@arifwidianto/msa-plugin-stdio](packages/plugin-stdio) | Standard I/O plugin with CLI capabilities |
+| [@arifwidianto/msa-plugin-langchain](packages/plugin-langchain) | LLM integration using Langchain |
+| [@arifwidianto/msa-plugin-mcp](packages/plugin-mcp) | Model Context Protocol implementation |
+| [@arifwidianto/msa-plugin-messagebroker](packages/plugin-messagebroker) | Message broker integration with RabbitMQ and Redis |
+
+## Installation
+
+```bash
+# Clone the repository
+git clone https://github.com/yourusername/msa.git
+cd msa
+
+# Install dependencies
+npm install
+
+# Build all packages
+npm run build
+```
+
+## Getting Started
+
+Here's a simple example of creating an HTTP service with LLM capabilities:
+
+```typescript
+import { Service } from '@arifwidianto/msa-core';
+import { HttpPlugin } from '@arifwidianto/msa-plugin-http';
+import { LangchainPlugin } from '@arifwidianto/msa-plugin-langchain';
+
+async function main() {
+  // Create a new service
+  const service = new Service();
+  
+  // Register plugins
+  const httpPlugin = new HttpPlugin();
+  const langchainPlugin = new LangchainPlugin();
+  
+  service.registerPlugin(httpPlugin);
+  service.registerPlugin(langchainPlugin);
+  
+  // Initialize service with configurations
+  await service.initializeService({
+    'msa-plugin-http': {
+      port: 3000
+    },
+    'msa-plugin-langchain': {
+      provider: 'openai',
+      auth: {
+        apiKey: 'your-api-key'
+      }
+    }
+  });
+  
+  // Register an HTTP route that uses the LangchainPlugin
+  httpPlugin.registerRoute('post', '/generate', async (req, res) => {
+    try {
+      const result = await langchainPlugin.invokeChain(
+        'Generate a response to: {prompt}',
+        { prompt: req.body.prompt }
+      );
+      res.json({ result });
+    } catch (error) {
+      res.status(500).json({ error: error.message });
+    }
+  });
+  
+  // Start the service
+  await service.startService();
+  
+  console.log('Service started on port 3000');
+}
+
+main().catch(console.error);
+```
+
+## Supported Service Types
+
+### StdIO (CLI) Services
+Transform your core logic into command-line interfaces and terminal-based applications with full stdin/stdout handling capabilities.
+
+### Microservices Architecture Components  
+Build scalable microservice ecosystems with flexible transport options:
+- **Message Broker Integration** - Connect via RabbitMQ, Apache Kafka, Redis Pub/Sub, or other messaging systems
+- **HTTP/WebSocket Services** - RESTful APIs and real-time bidirectional communication
+
+### RPC/JSON-RPC 2.0 Web Services
+Implement standards-compliant remote procedure call services with multiple transport mechanisms:
+- **HTTP API** - Traditional request/response with optional Server-Sent Events (SSE) for streaming
+- **WebSocket** - Full-duplex communication for real-time RPC interactions
+
+### AI-Powered Protocol Services
+Leverage integrated LLM capabilities with Langchain support for intelligent service interactions:
+- **Model Context Protocol (MCP)** - Build both MCP Clients and Servers for AI model communication and context management
+- **Google A2A Protocol (Agent-to-Agent)** - Create intelligent agents capable of autonomous inter-agent communication and coordination
+
+## Architecture Philosophy
+
+**Core + Plugins = Your AI-Enhanced Service**
+
+The MSA framework follows a minimalist core principle where the TypeScript-based package provides essential service lifecycle management and LLM integration capabilities, while specialized plugin packages handle transport layers, protocols, and service-specific functionality. This separation allows for:
+
+- **Mix and Match** - Combine multiple plugins for hybrid service capabilities with AI enhancements
+- **Transport Agnostic** - Switch between HTTP, WebSocket, message brokers, MCP, A2A, or CLI without core logic changes  
+- **AI-First Architecture** - Langchain integration at the core enables intelligent decision-making across all service types
+- **Protocol Aware** - Native support for modern AI protocols (MCP, A2A) alongside traditional communication patterns
+- **Lightweight Deployment** - Include only the capabilities your service actually needs
+- **Easy Testing** - Mock transport layers and LLM interactions independently from business logic
+
+## Use Cases
+
+- **AI-Powered API Gateways** - HTTP + WebSocket + MCP plugins for intelligent request routing
+- **Intelligent Background Workers** - Message Broker + A2A plugins for autonomous task processing
+- **Real-time AI Applications** - WebSocket + Langchain plugins for live AI-powered interactions
+- **AI DevOps Tools** - CLI + MCP plugins for intelligent automation utilities
+- **Multi-Agent Systems** - A2A + Message Broker plugins for distributed AI coordination
+- **LLM Context Servers** - MCP Server plugins for managing AI model contexts and capabilities
+- **Agent Orchestration Services** - A2A Client/Server + RPC plugins for complex AI workflows
+
+## Getting Started
+
+```bash
+npm install @arifwidianto/msa-core
+npm install @arifwidianto/msa-plugin-http @arifwidianto/msa-plugin-websocket  # Traditional services
+npm install @arifwidianto/msa-plugin-mcp @arifwidianto/msa-plugin-a2a        # AI protocol support
+npm install @arifwidianto/msa-plugin-langchain                              # LLM integration
+```
+
+Build once, deploy anywhere. Let your requirements drive the architecture, not the other way around. Whether you're building traditional microservices or cutting-edge AI agents, MSA adapts to your needs with TypeScript reliability and AI-first capabilities.
+
+## Development
+
+### Prerequisites
+
+- Node.js 18+
+- npm 9+
+
+### Available Scripts
+
+The monorepo uses Lerna for package management. The following scripts are available:
+
+| Command | Description |
+|---------|-------------|
+| `npm run build` | Build all packages |
+| `npm run clean` | Clean build artifacts |
+| `npm run dev` | Start development mode with file watching |
+| `npm run test` | Run all tests |
+| `npm run test:watch` | Run tests in watch mode |
+| `npm run test:coverage` | Run tests with coverage report |
+| `npm run lint` | Lint all packages |
+| `npm run bootstrap` | Bootstrap all packages (install dependencies) |
+| `npm run release` | Create a new release with Lerna |
+
+### Package Development
+
+Each package has its own scripts that can be run individually:
+
+```bash
+# Example: Build a specific package
+cd packages/plugin-http
+npm run build
+
+# Run tests for a specific package
+npm run test
+```
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+1. Fork the repository
+2. Create your feature branch (`git checkout -b feature/amazing-feature`)
+3. Commit your changes (`git commit -m 'Add some amazing feature'`)
+4. Push to the branch (`git push origin feature/amazing-feature`)
+5. Open a Pull Request
+
+## License
+
+This project is licensed under the MIT License - see the LICENSE file for details.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,21 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  projects: [
+    '<rootDir>/packages/core/jest.config.js',
+    '<rootDir>/packages/plugin-http/jest.config.js',
+    '<rootDir>/packages/plugin-websocket/jest.config.js',
+    '<rootDir>/packages/plugin-stdio/jest.config.js',
+    '<rootDir>/packages/plugin-langchain/jest.config.js',
+    '<rootDir>/packages/plugin-mcp/jest.config.js',
+    '<rootDir>/packages/plugin-messagebroker/jest.config.js',
+  ],
+  // Optional: Collect coverage from all packages
+  collectCoverage: true,
+  coverageDirectory: '<rootDir>/coverage/',
+  collectCoverageFrom: [
+    '<rootDir>/packages/*/src/**/*.ts',
+    '!<rootDir>/packages/*/src/**/index.ts', // Usually, index files just re-export, adjust if needed
+    '!<rootDir>/packages/*/src/**/*.d.ts', // Exclude type definition files
+  ],
+};

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,7 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.0.0"
+  "version": "0.0.0",
+  "packages": [
+    "packages/*"
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "msa-framework-monorepo",
+  "name": "@arifwidianto/msa",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "msa-framework-monorepo",
+      "name": "@arifwidianto/msa",
       "workspaces": [
         "packages/*"
       ],
@@ -638,6 +638,149 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
+      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+      "deprecated": "Use @eslint/config-array instead",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@hutson/parse-repository-url": {
       "version": "3.0.2",
@@ -1845,6 +1988,19 @@
         "@tybys/wasm-util": "^0.9.0"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2531,6 +2687,16 @@
         "@octokit/openapi-types": "^24.2.0"
       }
     },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -2831,6 +2997,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/express": {
       "version": "4.17.22",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.22.tgz",
@@ -2923,6 +3096,20 @@
         "pretty-format": "^29.0.0"
       }
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -2987,6 +3174,13 @@
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "license": "MIT"
     },
+    "node_modules/@types/semver": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.0.tgz",
+      "integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/send": {
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
@@ -3016,6 +3210,30 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.3.tgz",
+      "integrity": "sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
+      }
     },
     "node_modules/@types/through": {
       "version": "0.0.33",
@@ -3059,6 +3277,237 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
+      "integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.5.1",
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/type-utils": "6.21.0",
+        "@typescript-eslint/utils": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.4",
+        "natural-compare": "^1.4.0",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
+      "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
+      "integrity": "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "@typescript-eslint/utils": "6.21.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
+      "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
@@ -3162,6 +3611,29 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/add-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
@@ -3200,6 +3672,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/amqplib": {
@@ -3324,6 +3813,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
@@ -3334,6 +3830,15 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/axios": {
       "version": "1.9.0",
@@ -4099,6 +4604,16 @@
         "dot-prop": "^5.1.0"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4324,6 +4839,13 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
     },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -4516,6 +5038,13 @@
         }
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -4598,6 +5127,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
@@ -4627,6 +5167,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/dot-prop": {
@@ -4890,6 +5443,231 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/eslint": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eslint/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -4901,6 +5679,52 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/etag": {
@@ -5072,6 +5896,13 @@
         "node": ">=0.6.0"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -5107,6 +5938,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-redact": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
+      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -5139,6 +5993,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
       }
     },
     "node_modules/filelist": {
@@ -5237,6 +6104,80 @@
         "flat": "cli.js"
       }
     },
+    "node_modules/flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flat-cache/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/flat-cache/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/flat-cache/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/follow-redirects": {
       "version": "1.15.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
@@ -5325,6 +6266,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.5.tgz",
+      "integrity": "sha512-Oz5Hwvwak/DCaXVVUtPn4oLMLLy1CdclLKO1LFgU7XzDpVMUU5UjlSLpGMocyQNNk8F6IJW9M/YdooSn2MRI+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -5821,6 +6778,13 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/handlebars": {
       "version": "4.7.8",
@@ -6356,6 +7320,16 @@
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
       "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
       "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -7318,6 +8292,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -7332,6 +8313,20 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-stringify-nice": {
       "version": "1.1.4",
@@ -7423,6 +8418,16 @@
       "resolved": "https://registry.npmjs.org/just-diff-apply/-/just-diff-apply-5.5.0.tgz",
       "integrity": "sha512-OYTthRfSh55WOItVqwpefPtNt2VdKsq5AnAK6apdtR6yCH8pr0CmSr710J0Mf+WdQy7K/OzMy7K2MgAfdQURDw==",
       "dev": true
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -7832,6 +8837,20 @@
         "node": ">=6"
       }
     },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/libnpmaccess": {
       "version": "8.0.6",
       "resolved": "https://registry.npmjs.org/libnpmaccess/-/libnpmaccess-8.0.6.tgz",
@@ -7940,6 +8959,13 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -8542,6 +9568,16 @@
         "num-sort": "^2.0.0"
       }
     },
+    "node_modules/mock-socket": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.3.1.tgz",
+      "integrity": "sha512-qxBgB7Qa2sEQgHFjj0dSigq7fX4k6Saisd5Nelwp2q8mlbAFh5dHV9JTTlF8viYJLSSWgMCZFUom8PJcMNBoJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/modify-values": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
@@ -8990,6 +10026,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -9092,6 +10137,24 @@
       "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
       "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
       "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/ora": {
       "version": "5.4.1",
@@ -9490,6 +10553,52 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pino": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.7.0.tgz",
+      "integrity": "sha512-vnMCM6xZTb1WDmLvtG2lE/2p+t9hDEIvTWJsu6FejkE62vB7gDhvzrpFR4Cw2to+9JNQxVnkAKVPA1KPB98vWg==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-abstract-transport/node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
+      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
+      "license": "MIT"
+    },
     "node_modules/pirates": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
@@ -9523,6 +10632,16 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/pretty-format": {
@@ -9565,6 +10684,22 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/proggy": {
       "version": "2.0.0",
@@ -9663,6 +10798,16 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "devOptional": true
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pure-rand": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
@@ -9720,6 +10865,12 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
     },
     "node_modules/quick-lru": {
       "version": "4.0.1",
@@ -9995,6 +11146,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -10023,6 +11183,16 @@
         "@redis/json": "1.0.7",
         "@redis/search": "1.2.0",
         "@redis/time-series": "1.1.0"
+      }
+    },
+    "node_modules/redis-mock": {
+      "version": "0.56.3",
+      "resolved": "https://registry.npmjs.org/redis-mock/-/redis-mock-0.56.3.tgz",
+      "integrity": "sha512-ynaJhqk0Qf3Qajnwvy4aOjS4Mdf9IBkELWtjd+NYhpiqu4QCNq6Vf3Q7c++XRPGiKiwRj9HWr0crcwy7EiPjYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/require-directory": {
@@ -10247,6 +11417,15 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -10520,6 +11699,15 @@
         "node": ">= 14"
       }
     },
+    "node_modules/sonic-boom": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
+      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/sort-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
@@ -10789,6 +11977,56 @@
         "node": ">=4"
       }
     },
+    "node_modules/superagent": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
+      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
+      "deprecated": "Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^2.1.2",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=6.4.0 <13 || >=14"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.4.tgz",
+      "integrity": "sha512-erY3HFDG0dPnhw4U+udPfrzXa4xhSG+n4rxfRuZWCUvjFWwKl+OxWf/7zk50s84/fAAs7vf5QAb9uRa0cCykxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^8.1.2"
+      },
+      "engines": {
+        "node": ">=6.4.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -10946,6 +12184,22 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -11052,6 +12306,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
     "node_modules/ts-jest": {
       "version": "29.3.4",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.3.4.tgz",
@@ -11155,6 +12422,19 @@
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/type-detect": {
@@ -11318,6 +12598,16 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/url-parse": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
@@ -11466,6 +12756,16 @@
       "dev": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wordwrap": {
@@ -11743,8 +13043,34 @@
     "packages/core": {
       "name": "@arifwidianto/msa-core",
       "version": "0.1.0",
+      "dependencies": {
+        "pino": "^9.7.0"
+      },
       "devDependencies": {
+        "@types/jest": "^29.5.12",
+        "@typescript-eslint/eslint-plugin": "^6.9.1",
+        "@typescript-eslint/parser": "^6.9.1",
+        "eslint": "^8.52.0",
+        "jest": "^29.7.0",
+        "rimraf": "^5.0.5",
+        "ts-jest": "^29.1.2",
         "typescript": "^5.4.5"
+      }
+    },
+    "packages/core/node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "packages/plugin-http": {
@@ -11756,10 +13082,35 @@
       "devDependencies": {
         "@arifwidianto/msa-core": "0.1.0",
         "@types/express": "^4.17.21",
+        "@types/jest": "^29.5.12",
+        "@types/supertest": "^6.0.2",
+        "@typescript-eslint/eslint-plugin": "^6.9.1",
+        "@typescript-eslint/parser": "^6.9.1",
+        "eslint": "^8.52.0",
+        "jest": "^29.7.0",
+        "rimraf": "^5.0.5",
+        "supertest": "^6.3.4",
+        "ts-jest": "^29.1.2",
         "typescript": "^5.4.5"
       },
       "peerDependencies": {
         "@arifwidianto/msa-core": "0.1.0"
+      }
+    },
+    "packages/plugin-http/node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "packages/plugin-langchain": {
@@ -11772,10 +13123,33 @@
         "langchain": "^0.1.36"
       },
       "devDependencies": {
+        "@types/jest": "^29.5.12",
+        "@typescript-eslint/eslint-plugin": "^6.9.1",
+        "@typescript-eslint/parser": "^6.9.1",
+        "eslint": "^8.52.0",
+        "jest": "^29.7.0",
+        "rimraf": "^5.0.5",
+        "ts-jest": "^29.1.2",
         "typescript": "^5.4.5"
       },
       "peerDependencies": {
         "@arifwidianto/msa-core": "0.1.0"
+      }
+    },
+    "packages/plugin-langchain/node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "packages/plugin-mcp": {
@@ -11786,11 +13160,35 @@
         "ws": "^8.17.0"
       },
       "devDependencies": {
+        "@types/jest": "^29.5.12",
         "@types/ws": "^8.5.10",
+        "@typescript-eslint/eslint-plugin": "^6.9.1",
+        "@typescript-eslint/parser": "^6.9.1",
+        "eslint": "^8.52.0",
+        "jest": "^29.7.0",
+        "mock-socket": "^9.3.1",
+        "rimraf": "^5.0.5",
+        "ts-jest": "^29.1.2",
         "typescript": "^5.4.5"
       },
       "peerDependencies": {
         "@arifwidianto/msa-core": "0.1.0"
+      }
+    },
+    "packages/plugin-mcp/node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "packages/plugin-messagebroker": {
@@ -11803,10 +13201,34 @@
       },
       "devDependencies": {
         "@types/amqplib": "^0.10.5",
+        "@types/jest": "^29.5.12",
+        "@typescript-eslint/eslint-plugin": "^6.9.1",
+        "@typescript-eslint/parser": "^6.9.1",
+        "eslint": "^8.52.0",
+        "jest": "^29.7.0",
+        "redis-mock": "^0.56.3",
+        "rimraf": "^5.0.5",
+        "ts-jest": "^29.1.2",
         "typescript": "^5.4.5"
       },
       "peerDependencies": {
         "@arifwidianto/msa-core": "0.1.0"
+      }
+    },
+    "packages/plugin-messagebroker/node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "packages/plugin-stdio": {
@@ -11819,7 +13241,14 @@
       "devDependencies": {
         "@arifwidianto/msa-core": "0.1.0",
         "@types/inquirer": "^9.0.7",
+        "@types/jest": "^29.5.12",
         "@types/yargs": "^17.0.32",
+        "@typescript-eslint/eslint-plugin": "^6.9.1",
+        "@typescript-eslint/parser": "^6.9.1",
+        "eslint": "^8.52.0",
+        "jest": "^29.7.0",
+        "rimraf": "^5.0.5",
+        "ts-jest": "^29.1.2",
         "typescript": "^5.4.5"
       },
       "peerDependencies": {
@@ -11867,6 +13296,22 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "packages/plugin-stdio/node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "packages/plugin-stdio/node_modules/run-async": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
@@ -11884,11 +13329,35 @@
       },
       "devDependencies": {
         "@arifwidianto/msa-core": "0.1.0",
+        "@types/jest": "^29.5.12",
         "@types/ws": "^8.5.10",
+        "@typescript-eslint/eslint-plugin": "^6.9.1",
+        "@typescript-eslint/parser": "^6.9.1",
+        "eslint": "^8.52.0",
+        "jest": "^29.7.0",
+        "mock-socket": "^9.3.1",
+        "rimraf": "^5.0.5",
+        "ts-jest": "^29.1.2",
         "typescript": "^5.4.5"
       },
       "peerDependencies": {
         "@arifwidianto/msa-core": "0.1.0"
+      }
+    },
+    "packages/plugin-websocket/node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,58 @@
         "packages/*"
       ],
       "devDependencies": {
+        "@types/jest": "^29.5.12",
+        "jest": "^29.7.0",
         "lerna": "^8.2.2",
-        "typescript": "^5.8.3"
+        "ts-jest": "^29.1.2",
+        "typescript": "^5.4.5"
       }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.9.1.tgz",
+      "integrity": "sha512-wa1meQ2WSfoY8Uor3EdrJq0jTiZJoKoSii2ZVWRY1oN4Tlr5s59pADg9T79FTbPe1/se5c3pBeZgJL63wmuoBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "digest-fetch": "^1.3.0",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7",
+        "web-streams-polyfill": "^3.2.1"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
+      "version": "18.19.103",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.103.tgz",
+      "integrity": "sha512-hHTHp+sEz6SxFsp+SA+Tqrua3AbmlAw+Y//aEwdHrdZkYVRWdvWD3y5uPZ0flYOkgskaFWqZ/YGFm3FaFQ0pRw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
     },
     "node_modules/@arifwidianto/msa-core": {
       "resolved": "packages/core",
@@ -19,6 +68,18 @@
     },
     "node_modules/@arifwidianto/msa-plugin-http": {
       "resolved": "packages/plugin-http",
+      "link": true
+    },
+    "node_modules/@arifwidianto/msa-plugin-langchain": {
+      "resolved": "packages/plugin-langchain",
+      "link": true
+    },
+    "node_modules/@arifwidianto/msa-plugin-mcp": {
+      "resolved": "packages/plugin-mcp",
+      "link": true
+    },
+    "node_modules/@arifwidianto/msa-plugin-messagebroker": {
+      "resolved": "packages/plugin-messagebroker",
       "link": true
     },
     "node_modules/@arifwidianto/msa-plugin-stdio": {
@@ -43,6 +104,170 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/compat-data": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.2.tgz",
+      "integrity": "sha512-TUtMJYRPyUb/9aU8f3K0mjmjf6M9N5Woshn2CS6nqJSeJtTtQcpLUXjGt9vbF8ZGff0El99sWkLgzwW3VXnxZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.1.tgz",
+      "integrity": "sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.27.1",
+        "@babel/helper-compilation-targets": "^7.27.1",
+        "@babel/helper-module-transforms": "^7.27.1",
+        "@babel/helpers": "^7.27.1",
+        "@babel/parser": "^7.27.1",
+        "@babel/template": "^7.27.1",
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.1.tgz",
+      "integrity": "sha512-UnJfnIpc/+JO0/+KRVQNGU+y5taA5vCbwN8+azkX6beii/ZF+enZJSOKo11ZSzGJjlNfJHfQtmQT8H+9TXPG2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.27.1",
+        "@babel/types": "^7.27.1",
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.27.2",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.1.tgz",
+      "integrity": "sha512-9yHn519/8KvTU5BjTVEEeIM3w9/2yXNKoD82JifINImhpKkARMJKPP59kLo+BafpdN5zgNeIcS4jsGDmd3l58g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/traverse": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
@@ -51,6 +276,340 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.1.tgz",
+      "integrity": "sha512-FCvFTm0sWV8Fxhpp2McP5/W53GPllQ9QeQ7SiqGWjMf/LVG07lFa5+pgK05IRhVwtvafT22KF+ZSnM9I545CvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.2.tgz",
+      "integrity": "sha512-QYLs8299NA7WM/bZAdp+CviYYkVoYXlDW2rzliy3chxd1PQjej7JORuMJDJXJUb9g0TT+B99EwaVLKmX+sPXWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.27.1"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
+      "integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
+      "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
+      "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.1.tgz",
+      "integrity": "sha512-ZCYtZciz1IWJB4U61UPu4KEaqyfj+r5T1Q5mqPo+IBpcG9kHv30Z0aD8LXPgC1trYa6rK0orRyAhqUgk4MjmEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.27.1",
+        "@babel/parser": "^7.27.1",
+        "@babel/template": "^7.27.1",
+        "@babel/types": "^7.27.1",
+        "debug": "^4.3.1",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.1.tgz",
+      "integrity": "sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "1.4.3",
@@ -87,6 +646,15 @@
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.11.tgz",
+      "integrity": "sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -191,6 +759,286 @@
       "integrity": "sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ==",
       "dev": true
     },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -201,6 +1049,708 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.2"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/transform/node_modules/write-file-atomic": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/set-array": "^1.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@langchain/community": {
+      "version": "0.0.57",
+      "resolved": "https://registry.npmjs.org/@langchain/community/-/community-0.0.57.tgz",
+      "integrity": "sha512-tib4UJNkyA4TPNsTNChiBtZmThVJBr7X/iooSmKeCr+yUEha2Yxly3A4OAO95Vlpj4Q+od8HAfCbZih/1XqAMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@langchain/core": "~0.1.60",
+        "@langchain/openai": "~0.0.28",
+        "expr-eval": "^2.0.2",
+        "flat": "^5.0.2",
+        "langsmith": "~0.1.1",
+        "uuid": "^9.0.0",
+        "zod": "^3.22.3",
+        "zod-to-json-schema": "^3.22.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@aws-crypto/sha256-js": "^5.0.0",
+        "@aws-sdk/client-bedrock-agent-runtime": "^3.485.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.422.0",
+        "@aws-sdk/client-dynamodb": "^3.310.0",
+        "@aws-sdk/client-kendra": "^3.352.0",
+        "@aws-sdk/client-lambda": "^3.310.0",
+        "@aws-sdk/client-sagemaker-runtime": "^3.310.0",
+        "@aws-sdk/client-sfn": "^3.310.0",
+        "@aws-sdk/credential-provider-node": "^3.388.0",
+        "@azure/search-documents": "^12.0.0",
+        "@clickhouse/client": "^0.2.5",
+        "@cloudflare/ai": "*",
+        "@datastax/astra-db-ts": "^1.0.0",
+        "@elastic/elasticsearch": "^8.4.0",
+        "@getmetal/metal-sdk": "*",
+        "@getzep/zep-js": "^0.9.0",
+        "@gomomento/sdk": "^1.51.1",
+        "@gomomento/sdk-core": "^1.51.1",
+        "@google-ai/generativelanguage": "^0.2.1",
+        "@gradientai/nodejs-sdk": "^1.2.0",
+        "@huggingface/inference": "^2.6.4",
+        "@mlc-ai/web-llm": "^0.2.35",
+        "@mozilla/readability": "*",
+        "@neondatabase/serverless": "*",
+        "@opensearch-project/opensearch": "*",
+        "@pinecone-database/pinecone": "*",
+        "@planetscale/database": "^1.8.0",
+        "@premai/prem-sdk": "^0.3.25",
+        "@qdrant/js-client-rest": "^1.8.2",
+        "@raycast/api": "^1.55.2",
+        "@rockset/client": "^0.9.1",
+        "@smithy/eventstream-codec": "^2.0.5",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/signature-v4": "^2.0.10",
+        "@smithy/util-utf8": "^2.0.0",
+        "@supabase/postgrest-js": "^1.1.1",
+        "@supabase/supabase-js": "^2.10.0",
+        "@tensorflow-models/universal-sentence-encoder": "*",
+        "@tensorflow/tfjs-converter": "*",
+        "@tensorflow/tfjs-core": "*",
+        "@upstash/redis": "^1.20.6",
+        "@upstash/vector": "^1.0.7",
+        "@vercel/kv": "^0.2.3",
+        "@vercel/postgres": "^0.5.0",
+        "@writerai/writer-sdk": "^0.40.2",
+        "@xata.io/client": "^0.28.0",
+        "@xenova/transformers": "^2.5.4",
+        "@zilliz/milvus2-sdk-node": ">=2.2.7",
+        "better-sqlite3": "^9.4.0",
+        "cassandra-driver": "^4.7.2",
+        "cborg": "^4.1.1",
+        "chromadb": "*",
+        "closevector-common": "0.1.3",
+        "closevector-node": "0.1.6",
+        "closevector-web": "0.1.6",
+        "cohere-ai": "*",
+        "convex": "^1.3.1",
+        "couchbase": "^4.3.0",
+        "discord.js": "^14.14.1",
+        "dria": "^0.0.3",
+        "duck-duck-scrape": "^2.2.5",
+        "faiss-node": "^0.5.1",
+        "firebase-admin": "^11.9.0 || ^12.0.0",
+        "google-auth-library": "^8.9.0",
+        "googleapis": "^126.0.1",
+        "hnswlib-node": "^3.0.0",
+        "html-to-text": "^9.0.5",
+        "interface-datastore": "^8.2.11",
+        "ioredis": "^5.3.2",
+        "it-all": "^3.0.4",
+        "jsdom": "*",
+        "jsonwebtoken": "^9.0.2",
+        "llmonitor": "^0.5.9",
+        "lodash": "^4.17.21",
+        "lunary": "^0.6.11",
+        "mongodb": ">=5.2.0",
+        "mysql2": "^3.3.3",
+        "neo4j-driver": "*",
+        "node-llama-cpp": "*",
+        "pg": "^8.11.0",
+        "pg-copy-streams": "^6.0.5",
+        "pickleparser": "^0.2.1",
+        "portkey-ai": "^0.1.11",
+        "redis": "*",
+        "replicate": "^0.18.0",
+        "typeorm": "^0.3.12",
+        "typesense": "^1.5.3",
+        "usearch": "^1.1.1",
+        "vectordb": "^0.1.4",
+        "voy-search": "0.6.2",
+        "weaviate-ts-client": "*",
+        "web-auth-library": "^1.0.3",
+        "ws": "^8.14.2"
+      },
+      "peerDependenciesMeta": {
+        "@aws-crypto/sha256-js": {
+          "optional": true
+        },
+        "@aws-sdk/client-bedrock-agent-runtime": {
+          "optional": true
+        },
+        "@aws-sdk/client-bedrock-runtime": {
+          "optional": true
+        },
+        "@aws-sdk/client-dynamodb": {
+          "optional": true
+        },
+        "@aws-sdk/client-kendra": {
+          "optional": true
+        },
+        "@aws-sdk/client-lambda": {
+          "optional": true
+        },
+        "@aws-sdk/client-sagemaker-runtime": {
+          "optional": true
+        },
+        "@aws-sdk/client-sfn": {
+          "optional": true
+        },
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@azure/search-documents": {
+          "optional": true
+        },
+        "@clickhouse/client": {
+          "optional": true
+        },
+        "@cloudflare/ai": {
+          "optional": true
+        },
+        "@datastax/astra-db-ts": {
+          "optional": true
+        },
+        "@elastic/elasticsearch": {
+          "optional": true
+        },
+        "@getmetal/metal-sdk": {
+          "optional": true
+        },
+        "@getzep/zep-js": {
+          "optional": true
+        },
+        "@gomomento/sdk": {
+          "optional": true
+        },
+        "@gomomento/sdk-core": {
+          "optional": true
+        },
+        "@google-ai/generativelanguage": {
+          "optional": true
+        },
+        "@gradientai/nodejs-sdk": {
+          "optional": true
+        },
+        "@huggingface/inference": {
+          "optional": true
+        },
+        "@mlc-ai/web-llm": {
+          "optional": true
+        },
+        "@mozilla/readability": {
+          "optional": true
+        },
+        "@neondatabase/serverless": {
+          "optional": true
+        },
+        "@opensearch-project/opensearch": {
+          "optional": true
+        },
+        "@pinecone-database/pinecone": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@premai/prem-sdk": {
+          "optional": true
+        },
+        "@qdrant/js-client-rest": {
+          "optional": true
+        },
+        "@raycast/api": {
+          "optional": true
+        },
+        "@rockset/client": {
+          "optional": true
+        },
+        "@smithy/eventstream-codec": {
+          "optional": true
+        },
+        "@smithy/protocol-http": {
+          "optional": true
+        },
+        "@smithy/signature-v4": {
+          "optional": true
+        },
+        "@smithy/util-utf8": {
+          "optional": true
+        },
+        "@supabase/postgrest-js": {
+          "optional": true
+        },
+        "@supabase/supabase-js": {
+          "optional": true
+        },
+        "@tensorflow-models/universal-sentence-encoder": {
+          "optional": true
+        },
+        "@tensorflow/tfjs-converter": {
+          "optional": true
+        },
+        "@tensorflow/tfjs-core": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@upstash/vector": {
+          "optional": true
+        },
+        "@vercel/kv": {
+          "optional": true
+        },
+        "@vercel/postgres": {
+          "optional": true
+        },
+        "@writerai/writer-sdk": {
+          "optional": true
+        },
+        "@xata.io/client": {
+          "optional": true
+        },
+        "@xenova/transformers": {
+          "optional": true
+        },
+        "@zilliz/milvus2-sdk-node": {
+          "optional": true
+        },
+        "better-sqlite3": {
+          "optional": true
+        },
+        "cassandra-driver": {
+          "optional": true
+        },
+        "cborg": {
+          "optional": true
+        },
+        "chromadb": {
+          "optional": true
+        },
+        "closevector-common": {
+          "optional": true
+        },
+        "closevector-node": {
+          "optional": true
+        },
+        "closevector-web": {
+          "optional": true
+        },
+        "cohere-ai": {
+          "optional": true
+        },
+        "convex": {
+          "optional": true
+        },
+        "couchbase": {
+          "optional": true
+        },
+        "discord.js": {
+          "optional": true
+        },
+        "dria": {
+          "optional": true
+        },
+        "duck-duck-scrape": {
+          "optional": true
+        },
+        "faiss-node": {
+          "optional": true
+        },
+        "firebase-admin": {
+          "optional": true
+        },
+        "google-auth-library": {
+          "optional": true
+        },
+        "googleapis": {
+          "optional": true
+        },
+        "hnswlib-node": {
+          "optional": true
+        },
+        "html-to-text": {
+          "optional": true
+        },
+        "interface-datastore": {
+          "optional": true
+        },
+        "ioredis": {
+          "optional": true
+        },
+        "it-all": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "jsonwebtoken": {
+          "optional": true
+        },
+        "llmonitor": {
+          "optional": true
+        },
+        "lodash": {
+          "optional": true
+        },
+        "lunary": {
+          "optional": true
+        },
+        "mongodb": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "neo4j-driver": {
+          "optional": true
+        },
+        "node-llama-cpp": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "pg-copy-streams": {
+          "optional": true
+        },
+        "pickleparser": {
+          "optional": true
+        },
+        "portkey-ai": {
+          "optional": true
+        },
+        "redis": {
+          "optional": true
+        },
+        "replicate": {
+          "optional": true
+        },
+        "typeorm": {
+          "optional": true
+        },
+        "typesense": {
+          "optional": true
+        },
+        "usearch": {
+          "optional": true
+        },
+        "vectordb": {
+          "optional": true
+        },
+        "voy-search": {
+          "optional": true
+        },
+        "weaviate-ts-client": {
+          "optional": true
+        },
+        "web-auth-library": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@langchain/community/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@langchain/core": {
+      "version": "0.1.63",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.1.63.tgz",
+      "integrity": "sha512-+fjyYi8wy6x1P+Ee1RWfIIEyxd9Ee9jksEwvrggPwwI/p45kIDTdYTblXsM13y4mNWTiACyLSdbwnPaxxdoz+w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^5.0.0",
+        "camelcase": "6",
+        "decamelize": "1.2.0",
+        "js-tiktoken": "^1.0.12",
+        "langsmith": "~0.1.7",
+        "ml-distance": "^4.0.0",
+        "mustache": "^4.2.0",
+        "p-queue": "^6.6.2",
+        "p-retry": "4",
+        "uuid": "^9.0.0",
+        "zod": "^3.22.4",
+        "zod-to-json-schema": "^3.22.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@langchain/core/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@langchain/core/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@langchain/core/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@langchain/openai": {
+      "version": "0.0.28",
+      "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-0.0.28.tgz",
+      "integrity": "sha512-2s1RA3/eAnz4ahdzsMPBna9hfAqpFNlWdHiPxVGZ5yrhXsbLWWoPcF+22LCk9t0HJKtazi2GCIWc0HVXH9Abig==",
+      "license": "MIT",
+      "dependencies": {
+        "@langchain/core": "~0.1.56",
+        "js-tiktoken": "^1.0.7",
+        "openai": "^4.32.1",
+        "zod": "^3.22.4",
+        "zod-to-json-schema": "^3.22.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@langchain/textsplitters": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@langchain/textsplitters/-/textsplitters-0.0.3.tgz",
+      "integrity": "sha512-cXWgKE3sdWLSqAa8ykbCcUsUF1Kyr5J3HOWYGuobhPEycXW4WI++d5DhzdpL238mzoEXTi90VqfSCra37l5YqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@langchain/core": ">0.2.0 <0.3.0",
+        "js-tiktoken": "^1.0.12"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@langchain/textsplitters/node_modules/@langchain/core": {
+      "version": "0.2.36",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.2.36.tgz",
+      "integrity": "sha512-qHLvScqERDeH7y2cLuJaSAlMwg3f/3Oc9nayRSXRU2UuaK/SOhI42cxiPLj1FnuHJSmN0rBQFkrLx02gI4mcVg==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^5.0.0",
+        "camelcase": "6",
+        "decamelize": "1.2.0",
+        "js-tiktoken": "^1.0.12",
+        "langsmith": "^0.1.56-rc.1",
+        "mustache": "^4.2.0",
+        "p-queue": "^6.6.2",
+        "p-retry": "4",
+        "uuid": "^10.0.0",
+        "zod": "^3.22.4",
+        "zod-to-json-schema": "^3.22.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@langchain/textsplitters/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@langchain/textsplitters/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@lerna/create": {
@@ -991,6 +2541,65 @@
         "node": ">=14"
       }
     },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
+      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
     "node_modules/@sigstore/bundle": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-2.3.2.tgz",
@@ -1071,6 +2680,26 @@
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "dev": true
     },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
     "node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz",
@@ -1126,6 +2755,181 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/amqplib": {
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.10.7.tgz",
+      "integrity": "sha512-IVj3avf9AQd2nXCx0PGk/OYq7VmHiyNxWFSb5HhU9ATh+i+gHWvVcljFTcTWQ/dyHJCTrzCixde+r/asL2ErDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.7.tgz",
+      "integrity": "sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.20.7"
+      }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.5",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
+      "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.22",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.22.tgz",
+      "integrity": "sha512-eZUmSnhRX9YRSkplpz0N+k6NljUUn5l3EWZIKZvYzhvMphEuNiyyy1viH/ejgt66JWgALwC/gtSUAeQKtSwW/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
+      "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/graceful-fs": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
+      "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/inquirer": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-9.0.8.tgz",
+      "integrity": "sha512-CgPD5kFGWsb8HJ5K7rfWlifao87m4ph8uioU7OTncJevmE/VLIqAAjfQtko578JZg7/f69K4FgqYym3gNr7DeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/through": "*",
+        "rxjs": "^7.2.0"
+      }
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -1138,11 +2942,123 @@
       "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
       "dev": true
     },
+    "node_modules/@types/node": {
+      "version": "22.15.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.21.tgz",
+      "integrity": "sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true
+    },
+    "node_modules/@types/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
+      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
+      "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/through": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.33.tgz",
+      "integrity": "sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.33",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+      "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
@@ -1212,6 +3128,40 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/add-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
@@ -1227,6 +3177,18 @@
         "node": ">= 14"
       }
     },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -1238,6 +3200,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/amqplib": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.10.8.tgz",
+      "integrity": "sha512-Tfn1O9sFgAP8DqeMEpt2IacsVTENBpblB3SqLdn0jK2AeX8iyCvbptBc8lyATT9bQ31MsjVwUSQ1g8f4jHOUfw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-more-ints": "~1.0.0",
+        "url-parse": "~1.5.10"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ansi-colors": {
@@ -1253,7 +3228,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
       "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "dev": true,
       "dependencies": {
         "type-fest": "^0.21.3"
       },
@@ -1268,7 +3242,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -1277,7 +3250,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -1286,6 +3258,20 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/aproba": {
@@ -1297,8 +3283,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/array-differ": {
       "version": "3.0.0",
@@ -1308,6 +3293,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
     },
     "node_modules/array-ify": {
       "version": "1.0.0",
@@ -1342,18 +3333,143 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
       "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/babel-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "^29.7.0",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^29.6.3",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.8.0"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^5.0.4",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.1.0.tgz",
+      "integrity": "sha512-ldYss8SbBlWva1bs28q78Ju5Zq1F+8BrqBZZ0VFhLBvhh6lCpC2o3gDJi/5DRLs9FgYZCnmPYIVFU4lRXCkyUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1362,11 +3478,15 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base-64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
+      "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1403,16 +3523,72 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/binary-search": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.6.tgz",
+      "integrity": "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA==",
+      "license": "CC0-1.0"
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
       }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.13.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -1436,11 +3612,66 @@
         "node": ">=8"
       }
     },
+    "node_modules/browserslist": {
+      "version": "4.24.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.5.tgz",
+      "integrity": "sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001716",
+        "electron-to-chromium": "^1.5.149",
+        "node-releases": "^2.0.19",
+        "update-browserslist-db": "^1.1.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-int64": "^0.4.0"
+      }
+    },
     "node_modules/buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1466,6 +3697,12 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "node_modules/buffer-more-ints": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
+      "integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg==",
+      "license": "MIT"
+    },
     "node_modules/byte-size": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/byte-size/-/byte-size-8.1.1.tgz",
@@ -1473,6 +3710,15 @@
       "dev": true,
       "engines": {
         "node": ">=12.17"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/cacache": {
@@ -1502,13 +3748,28 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -1546,11 +3807,31 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001718",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
+      "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
     "node_modules/chalk": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
       "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -1562,11 +3843,29 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/chardet": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
-      "dev": true
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+    },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/chownr": {
       "version": "2.0.0",
@@ -1592,6 +3891,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -1605,7 +3911,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
       "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "dev": true,
       "dependencies": {
         "restore-cursor": "^3.1.0"
       },
@@ -1617,7 +3922,6 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
       "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       },
@@ -1638,7 +3942,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -1652,7 +3955,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -1669,7 +3971,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-      "dev": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -1688,6 +3989,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/cmd-shim": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-6.0.3.tgz",
@@ -1697,11 +4007,28 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -1712,8 +4039,7 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/color-support": {
       "version": "1.1.3",
@@ -1741,12 +4067,20 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/common-ancestor-path": {
@@ -1791,6 +4125,27 @@
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
       "dev": true
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/conventional-changelog-angular": {
       "version": "7.0.0",
@@ -1947,6 +4302,28 @@
         "node": ">=14"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -1977,6 +4354,28 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/create-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "prompts": "^2.0.1"
+      },
+      "bin": {
+        "create-jest": "bin/create-jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -2012,6 +4411,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/cssesc": {
@@ -2065,7 +4473,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2109,11 +4516,20 @@
         }
       }
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/defaults": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
       "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
-      "dev": true,
       "dependencies": {
         "clone": "^1.0.2"
       },
@@ -2134,9 +4550,17 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/deprecation": {
@@ -2144,6 +4568,16 @@
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
       "dev": true
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
     },
     "node_modules/detect-indent": {
       "version": "5.0.0",
@@ -2154,6 +4588,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
@@ -2161,6 +4605,16 @@
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/digest-fetch": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/digest-fetch/-/digest-fetch-1.3.0.tgz",
+      "integrity": "sha512-CGJuv6iKNM7QyZlM2T3sPAdZWd/p9zQiRNS9G+9COUCwzWFTs0Xp8NF5iePx7wtvhDykReiRRrSeNb4oMmB8lA==",
+      "license": "ISC",
+      "dependencies": {
+        "base-64": "^0.1.0",
+        "md5": "^2.3.0"
       }
     },
     "node_modules/dir-glob": {
@@ -2218,7 +4672,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -2240,6 +4693,12 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/ejs": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
@@ -2255,17 +4714,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.157",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.157.tgz",
+      "integrity": "sha512-/0ybgsQd1muo8QlnuTpKwtl0oX5YMlUGbm8xyqgDU00motRkKFFbUJySAQBWcY79rVqNLWIWa87BGVGClwAB2w==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/encoding": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
@@ -2275,7 +4761,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -2345,7 +4830,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -2354,7 +4838,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -2363,7 +4846,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -2375,7 +4857,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
@@ -2390,10 +4871,15 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
@@ -2417,11 +4903,28 @@
         "node": ">=4"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "dev": true
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "node_modules/execa": {
       "version": "5.0.0",
@@ -2446,17 +4949,109 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/exponential-backoff": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.2.tgz",
       "integrity": "sha512-8QxYTVXUkuy7fIIoitQkPwGonB8F3Zj8eEO8Sqg9Zv/bkI7RJAzowee4gr81Hak/dUTpA2Z7VfQgoijjPNlUZA==",
       "dev": true
     },
+    "node_modules/expr-eval": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/expr-eval/-/expr-eval-2.0.2.tgz",
+      "integrity": "sha512-4EMSHGOPSwAfBiibw3ndnP0AvjDWLsMvGOvWEZ2F96IGk0bIVdjQisOHxReSkE13mHcfbuCiXw+G4y0zv6N8Eg==",
+      "license": "MIT"
+    },
+    "node_modules/express": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.3",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.7.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.3.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
     "node_modules/external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
       "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "dev": true,
       "dependencies": {
         "chardet": "^0.7.0",
         "iconv-lite": "^0.4.24",
@@ -2470,7 +5065,6 @@
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
       "dependencies": {
         "os-tmpdir": "~1.0.2"
       },
@@ -2506,6 +5100,13 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -2513,6 +5114,16 @@
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bser": "2.1.1"
       }
     },
     "node_modules/figures": {
@@ -2572,6 +5183,39 @@
         "node": ">=8"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/finalhandler/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -2589,7 +5233,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
       "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-      "dev": true,
       "bin": {
         "flat": "cli.js"
       }
@@ -2598,7 +5241,7 @@
       "version": "1.15.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
       "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "individual",
@@ -2646,7 +5289,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
       "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -2655,6 +5297,52 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
+    "node_modules/formdata-node/node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/front-matter": {
@@ -2732,20 +5420,52 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -2754,7 +5474,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -2772,6 +5491,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/get-pkg-repo": {
@@ -2887,7 +5616,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -3047,6 +5775,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/globby": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -3071,7 +5809,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -3089,7 +5826,7 @@
       "version": "4.7.8",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
       "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.2",
@@ -3119,7 +5856,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3128,7 +5864,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -3140,7 +5875,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -3161,7 +5895,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -3181,11 +5914,34 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "dev": true
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -3222,11 +5978,19 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -3238,7 +6002,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3258,7 +6021,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 4"
       }
@@ -3361,11 +6124,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -3446,11 +6220,32 @@
         "node": ">= 12"
       }
     },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-any-array": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-any-array/-/is-any-array-2.0.1.tgz",
+      "integrity": "sha512-UtilS7hLRu++wb/WBAw9bNuP1Eg04Ivn1vERJck8zJthEvXCBEBpGR/33u/xLKWEQf95803oalHrVDptcAvFdQ==",
+      "license": "MIT"
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "license": "MIT"
     },
     "node_modules/is-ci": {
       "version": "3.0.1",
@@ -3507,9 +6302,18 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/is-glob": {
@@ -3528,7 +6332,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
       "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3612,7 +6415,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -3654,6 +6456,77 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
+      "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jackspeak": {
@@ -3701,6 +6574,227 @@
         "node": "*"
       }
     },
+    "node_modules/jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^29.7.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.0.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^1.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.7.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
+        "exit": "^0.1.2",
+        "import-local": "^3.0.2",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-config/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/jest-diff": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
@@ -3716,6 +6810,54 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/jest-get-type": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
@@ -3723,6 +6865,421 @@
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.6.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "^29.6.3",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "leven": "^3.1.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/js-tiktoken": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.20.tgz",
+      "integrity": "sha512-Xlaqhhs8VfCd6Sh7a1cFkZHQbYTLCwVJJWiHVxBYzLPxW0XsoxBy1hitmjkdIjD3Aon5BXLHFwU5O8WUx6HH+A==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.5.1"
       }
     },
     "node_modules/js-tokens": {
@@ -3735,7 +7292,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -3748,6 +7304,19 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
       "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
       "dev": true
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
@@ -3818,6 +7387,15 @@
         "node >= 0.2.0"
       ]
     },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
@@ -3853,6 +7431,301 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/langchain": {
+      "version": "0.1.37",
+      "resolved": "https://registry.npmjs.org/langchain/-/langchain-0.1.37.tgz",
+      "integrity": "sha512-rpaLEJtRrLYhAViEp7/aHfSkxbgSqHJ5n10tXv3o4kHP/wOin85RpTgewwvGjEaKc3797jOg+sLSk6a7e0UlMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.9.1",
+        "@langchain/community": "~0.0.47",
+        "@langchain/core": "~0.1.60",
+        "@langchain/openai": "~0.0.28",
+        "@langchain/textsplitters": "~0.0.0",
+        "binary-extensions": "^2.2.0",
+        "js-tiktoken": "^1.0.7",
+        "js-yaml": "^4.1.0",
+        "jsonpointer": "^5.0.1",
+        "langchainhub": "~0.0.8",
+        "langsmith": "~0.1.7",
+        "ml-distance": "^4.0.0",
+        "openapi-types": "^12.1.3",
+        "p-retry": "4",
+        "uuid": "^9.0.0",
+        "yaml": "^2.2.1",
+        "zod": "^3.22.4",
+        "zod-to-json-schema": "^3.22.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-s3": "^3.310.0",
+        "@aws-sdk/client-sagemaker-runtime": "^3.310.0",
+        "@aws-sdk/client-sfn": "^3.310.0",
+        "@aws-sdk/credential-provider-node": "^3.388.0",
+        "@azure/storage-blob": "^12.15.0",
+        "@browserbasehq/sdk": "*",
+        "@gomomento/sdk": "^1.51.1",
+        "@gomomento/sdk-core": "^1.51.1",
+        "@gomomento/sdk-web": "^1.51.1",
+        "@google-ai/generativelanguage": "^0.2.1",
+        "@google-cloud/storage": "^6.10.1 || ^7.7.0",
+        "@mendable/firecrawl-js": "^0.0.13",
+        "@notionhq/client": "^2.2.10",
+        "@pinecone-database/pinecone": "*",
+        "@supabase/supabase-js": "^2.10.0",
+        "@vercel/kv": "^0.2.3",
+        "@xata.io/client": "^0.28.0",
+        "apify-client": "^2.7.1",
+        "assemblyai": "^4.0.0",
+        "axios": "*",
+        "cheerio": "^1.0.0-rc.12",
+        "chromadb": "*",
+        "convex": "^1.3.1",
+        "couchbase": "^4.3.0",
+        "d3-dsv": "^2.0.0",
+        "epub2": "^3.0.1",
+        "fast-xml-parser": "*",
+        "google-auth-library": "^8.9.0",
+        "handlebars": "^4.7.8",
+        "html-to-text": "^9.0.5",
+        "ignore": "^5.2.0",
+        "ioredis": "^5.3.2",
+        "jsdom": "*",
+        "mammoth": "^1.6.0",
+        "mongodb": ">=5.2.0",
+        "node-llama-cpp": "*",
+        "notion-to-md": "^3.1.0",
+        "officeparser": "^4.0.4",
+        "pdf-parse": "1.1.1",
+        "peggy": "^3.0.2",
+        "playwright": "^1.32.1",
+        "puppeteer": "^19.7.2",
+        "pyodide": "^0.24.1",
+        "redis": "^4.6.4",
+        "sonix-speech-recognition": "^2.1.1",
+        "srt-parser-2": "^1.2.3",
+        "typeorm": "^0.3.12",
+        "weaviate-ts-client": "*",
+        "web-auth-library": "^1.0.3",
+        "ws": "^8.14.2",
+        "youtube-transcript": "^1.0.6",
+        "youtubei.js": "^9.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/client-s3": {
+          "optional": true
+        },
+        "@aws-sdk/client-sagemaker-runtime": {
+          "optional": true
+        },
+        "@aws-sdk/client-sfn": {
+          "optional": true
+        },
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@azure/storage-blob": {
+          "optional": true
+        },
+        "@browserbasehq/sdk": {
+          "optional": true
+        },
+        "@gomomento/sdk": {
+          "optional": true
+        },
+        "@gomomento/sdk-core": {
+          "optional": true
+        },
+        "@gomomento/sdk-web": {
+          "optional": true
+        },
+        "@google-ai/generativelanguage": {
+          "optional": true
+        },
+        "@google-cloud/storage": {
+          "optional": true
+        },
+        "@mendable/firecrawl-js": {
+          "optional": true
+        },
+        "@notionhq/client": {
+          "optional": true
+        },
+        "@pinecone-database/pinecone": {
+          "optional": true
+        },
+        "@supabase/supabase-js": {
+          "optional": true
+        },
+        "@vercel/kv": {
+          "optional": true
+        },
+        "@xata.io/client": {
+          "optional": true
+        },
+        "apify-client": {
+          "optional": true
+        },
+        "assemblyai": {
+          "optional": true
+        },
+        "axios": {
+          "optional": true
+        },
+        "cheerio": {
+          "optional": true
+        },
+        "chromadb": {
+          "optional": true
+        },
+        "convex": {
+          "optional": true
+        },
+        "couchbase": {
+          "optional": true
+        },
+        "d3-dsv": {
+          "optional": true
+        },
+        "epub2": {
+          "optional": true
+        },
+        "faiss-node": {
+          "optional": true
+        },
+        "fast-xml-parser": {
+          "optional": true
+        },
+        "google-auth-library": {
+          "optional": true
+        },
+        "handlebars": {
+          "optional": true
+        },
+        "html-to-text": {
+          "optional": true
+        },
+        "ignore": {
+          "optional": true
+        },
+        "ioredis": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "mammoth": {
+          "optional": true
+        },
+        "mongodb": {
+          "optional": true
+        },
+        "node-llama-cpp": {
+          "optional": true
+        },
+        "notion-to-md": {
+          "optional": true
+        },
+        "officeparser": {
+          "optional": true
+        },
+        "pdf-parse": {
+          "optional": true
+        },
+        "peggy": {
+          "optional": true
+        },
+        "playwright": {
+          "optional": true
+        },
+        "puppeteer": {
+          "optional": true
+        },
+        "pyodide": {
+          "optional": true
+        },
+        "redis": {
+          "optional": true
+        },
+        "sonix-speech-recognition": {
+          "optional": true
+        },
+        "srt-parser-2": {
+          "optional": true
+        },
+        "typeorm": {
+          "optional": true
+        },
+        "weaviate-ts-client": {
+          "optional": true
+        },
+        "web-auth-library": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        },
+        "youtube-transcript": {
+          "optional": true
+        },
+        "youtubei.js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/langchain/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/langchainhub": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/langchainhub/-/langchainhub-0.0.11.tgz",
+      "integrity": "sha512-WnKI4g9kU2bHQP136orXr2bcRdgz9iiTBpTN0jWt9IlScUKnJBoD0aa2HOzHURQKeQDnt2JwqVmQ6Depf5uDLQ==",
+      "license": "MIT"
+    },
+    "node_modules/langsmith": {
+      "version": "0.1.68",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.1.68.tgz",
+      "integrity": "sha512-otmiysWtVAqzMx3CJ4PrtUBhWRG5Co8Z4o7hSZENPjlit9/j3/vm3TSvbaxpDYakZxtMjhkcJTqrdYFipISEiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/uuid": "^10.0.0",
+        "commander": "^10.0.1",
+        "p-queue": "^6.6.2",
+        "p-retry": "4",
+        "semver": "^7.6.3",
+        "uuid": "^10.0.0"
+      },
+      "peerDependencies": {
+        "openai": "*"
+      },
+      "peerDependenciesMeta": {
+        "openai": {
+          "optional": true
+        }
       }
     },
     "node_modules/lerna": {
@@ -3947,6 +7820,16 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/libnpmaccess": {
@@ -4045,7 +7928,7 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/lodash.ismatch": {
       "version": "4.4.0",
@@ -4053,11 +7936,17 @@
       "integrity": "sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==",
       "dev": true
     },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/log-symbols": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
       "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-      "dev": true,
       "dependencies": {
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
@@ -4090,6 +7979,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/make-fetch-happen": {
       "version": "13.0.1",
       "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-13.0.1.tgz",
@@ -4113,6 +8009,16 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tmpl": "1.0.5"
+      }
+    },
     "node_modules/map-obj": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
@@ -4129,9 +8035,28 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/meow": {
@@ -4296,6 +8221,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -4311,6 +8245,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -4324,11 +8267,22 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -4337,7 +8291,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -4349,7 +8302,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -4379,7 +8331,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
+      "devOptional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4545,6 +8497,51 @@
         "node": ">=10"
       }
     },
+    "node_modules/ml-array-mean": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/ml-array-mean/-/ml-array-mean-1.1.6.tgz",
+      "integrity": "sha512-MIdf7Zc8HznwIisyiJGRH9tRigg3Yf4FldW8DxKxpCCv/g5CafTw0RRu51nojVEOXuCQC7DRVVu5c7XXO/5joQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ml-array-sum": "^1.1.6"
+      }
+    },
+    "node_modules/ml-array-sum": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/ml-array-sum/-/ml-array-sum-1.1.6.tgz",
+      "integrity": "sha512-29mAh2GwH7ZmiRnup4UyibQZB9+ZLyMShvt4cH4eTK+cL2oEMIZFnSyB3SS8MlsTh6q/w/yh48KmqLxmovN4Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-any-array": "^2.0.0"
+      }
+    },
+    "node_modules/ml-distance": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/ml-distance/-/ml-distance-4.0.1.tgz",
+      "integrity": "sha512-feZ5ziXs01zhyFUUUeZV5hwc0f5JW0Sh0ckU1koZe/wdVkJdGxcP06KNQuF0WBTj8FttQUzcvQcpcrOp/XrlEw==",
+      "license": "MIT",
+      "dependencies": {
+        "ml-array-mean": "^1.1.6",
+        "ml-distance-euclidean": "^2.0.0",
+        "ml-tree-similarity": "^1.0.0"
+      }
+    },
+    "node_modules/ml-distance-euclidean": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ml-distance-euclidean/-/ml-distance-euclidean-2.0.0.tgz",
+      "integrity": "sha512-yC9/2o8QF0A3m/0IXqCTXCzz2pNEzvmcE/9HFKOZGnTjatvBbsn4lWYJkxENkA4Ug2fnYl7PXQxnPi21sgMy/Q==",
+      "license": "MIT"
+    },
+    "node_modules/ml-tree-similarity": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ml-tree-similarity/-/ml-tree-similarity-1.0.0.tgz",
+      "integrity": "sha512-XJUyYqjSuUQkNQHMscr6tcjldsOoAekxADTplt40QKfwW6nd++1wHWV9AArl0Zvw/TIHgNaZZNvr8QGvE8wLRg==",
+      "license": "MIT",
+      "dependencies": {
+        "binary-search": "^1.3.5",
+        "num-sort": "^2.0.0"
+      }
+    },
     "node_modules/modify-values": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
@@ -4557,8 +8554,7 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/multimatch": {
       "version": "5.0.0",
@@ -4588,11 +8584,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
     "node_modules/mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/negotiator": {
       "version": "0.6.4",
@@ -4607,13 +8619,32 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true
+      "devOptional": true
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -4653,11 +8684,25 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-machine-id": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/node-machine-id/-/node-machine-id-1.1.12.tgz",
       "integrity": "sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ==",
       "dev": true
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/nopt": {
       "version": "7.2.1",
@@ -4686,6 +8731,16 @@
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/npm-bundled": {
@@ -4792,6 +8847,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/num-sort": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/num-sort/-/num-sort-2.1.0.tgz",
+      "integrity": "sha512-1MQz1Ed8z2yckoBeSfkQHHO9K1yDRxxtotKSJ9yvcTUUxSvfvzEq5GwBrjjHEpMlq/k5gvXdmJ1SbYxWtpNoVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/nx": {
@@ -4911,6 +8978,30 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -4924,7 +9015,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -4952,11 +9042,61 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openai": {
+      "version": "4.103.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.103.0.tgz",
+      "integrity": "sha512-eWcz9kdurkGOFDtd5ySS5y251H2uBgq9+1a2lTBnjMMzlexJ40Am5t6Mu76SSE87VvitPa0dkIAp75F+dZVC0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/openai/node_modules/@types/node": {
+      "version": "18.19.103",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.103.tgz",
+      "integrity": "sha512-hHTHp+sEz6SxFsp+SA+Tqrua3AbmlAw+Y//aEwdHrdZkYVRWdvWD3y5uPZ0flYOkgskaFWqZ/YGFm3FaFQ0pRw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/openai/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT"
+    },
     "node_modules/ora": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
       "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
-      "dev": true,
       "dependencies": {
         "bl": "^4.1.0",
         "chalk": "^4.1.0",
@@ -4979,7 +9119,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4988,7 +9127,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -5060,7 +9198,6 @@
       "version": "6.6.2",
       "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
       "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
-      "dev": true,
       "dependencies": {
         "eventemitter3": "^4.0.4",
         "p-timeout": "^3.2.0"
@@ -5081,11 +9218,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-retry/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/p-timeout": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
       "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
-      "dev": true,
       "dependencies": {
         "p-finally": "^1.0.0"
       },
@@ -5228,6 +9386,15 @@
         "parse-path": "^7.0.0"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5235,6 +9402,16 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -5267,6 +9444,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -5305,6 +9488,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/pkg-dir": {
@@ -5419,6 +9612,20 @@
         "node": ">=10"
       }
     },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/promzard": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/promzard/-/promzard-1.0.2.tgz",
@@ -5437,11 +9644,62 @@
       "integrity": "sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==",
       "dev": true
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
+      "devOptional": true
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -5470,6 +9728,30 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/react-is": {
@@ -5704,7 +9986,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -5727,14 +10008,36 @@
         "node": ">=8"
       }
     },
+    "node_modules/redis": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
+      "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.1",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -5790,7 +10093,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
       "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "dev": true,
       "dependencies": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -5923,7 +10225,6 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -5932,7 +10233,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5951,14 +10251,12 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -5966,11 +10264,80 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
     },
     "node_modules/shallow-clone": {
       "version": "3.0.1",
@@ -6005,11 +10372,82 @@
         "node": ">=8"
       }
     },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
     "node_modules/sigstore": {
       "version": "2.3.1",
@@ -6027,6 +10465,13 @@
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -6091,9 +10536,20 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/spdx-correct": {
@@ -6167,20 +10623,64 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -6209,7 +10709,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -6260,6 +10759,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/strong-log-transformer": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/strong-log-transformer/-/strong-log-transformer-2.1.0.tgz",
@@ -6281,7 +10793,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -6376,6 +10887,56 @@
         "node": ">=4"
       }
     },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/text-extensions": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
@@ -6440,6 +11001,13 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -6452,11 +11020,19 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/treeverse": {
       "version": "3.0.0",
@@ -6474,6 +11050,69 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ts-jest": {
+      "version": "29.3.4",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.3.4.tgz",
+      "integrity": "sha512-Iqbrm8IXOmV+ggWHOTEbjwyCf2xZlUMv5npExksXohL+tk8va4Fjhb+X2+Rt9NBmgO7bJ8WpnMLOwih/DnMlFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "ejs": "^3.1.10",
+        "fast-json-stable-stringify": "^2.1.0",
+        "jest-util": "^29.0.0",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.7.2",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0",
+        "@jest/types": "^29.0.0",
+        "babel-jest": "^29.0.0",
+        "jest": "^29.0.0",
+        "typescript": ">=4.3 <6"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -6502,8 +11141,7 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/tuf-js": {
       "version": "2.2.1",
@@ -6519,16 +11157,38 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/type-fest": {
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/typedarray": {
@@ -6562,6 +11222,12 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
     },
     "node_modules/unique-filename": {
       "version": "3.0.0",
@@ -6602,6 +11268,15 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/upath": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
@@ -6612,23 +11287,86 @@
         "yarn": "*"
       }
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/uuid": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
       }
     },
     "node_modules/validate-npm-package-license": {
@@ -6650,32 +11388,57 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/walk-up-path": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-3.0.1.tgz",
       "integrity": "sha512-9YlCL/ynK3CTlrSRrDxZvUauLzAswPCrsaCgilqFevUYpeEW0/3ScEjaa3kbW/T0ghhkEr7mv+fpjqn1Y1YuTA==",
       "dev": true
     },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "makeerror": "1.0.12"
+      }
+    },
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
       "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
-      "dev": true,
       "dependencies": {
         "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -6709,13 +11472,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/wrap-ansi": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -6856,6 +11618,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/ws": {
+      "version": "8.18.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -6869,7 +11652,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -6877,14 +11659,12 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
       "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-      "dev": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -6896,7 +11676,6 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -6914,33 +11693,202 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       }
     },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
+      "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.23",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.23.tgz",
+      "integrity": "sha512-Od2bdMosahjSrSgJtakrwjMDb1zM1A3VIHCPGveZt/3/wlrTWBya2lmEh2OYe4OIu8mPTmmr0gnLHIWQXdtWBg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.5",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
+      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.24.1"
+      }
+    },
     "packages/core": {
+      "name": "@arifwidianto/msa-core",
       "version": "0.1.0",
       "devDependencies": {
         "typescript": "^5.4.5"
       }
     },
     "packages/plugin-http": {
+      "name": "@arifwidianto/msa-plugin-http",
       "version": "0.1.0",
+      "dependencies": {
+        "express": "^4.19.2"
+      },
+      "devDependencies": {
+        "@arifwidianto/msa-core": "0.1.0",
+        "@types/express": "^4.17.21",
+        "typescript": "^5.4.5"
+      },
+      "peerDependencies": {
+        "@arifwidianto/msa-core": "0.1.0"
+      }
+    },
+    "packages/plugin-langchain": {
+      "name": "@arifwidianto/msa-plugin-langchain",
+      "version": "0.1.0",
+      "dependencies": {
+        "@arifwidianto/msa-core": "0.1.0",
+        "@langchain/core": "^0.1.30",
+        "@langchain/openai": "^0.0.28",
+        "langchain": "^0.1.36"
+      },
       "devDependencies": {
         "typescript": "^5.4.5"
+      },
+      "peerDependencies": {
+        "@arifwidianto/msa-core": "0.1.0"
+      }
+    },
+    "packages/plugin-mcp": {
+      "name": "@arifwidianto/msa-plugin-mcp",
+      "version": "0.1.0",
+      "dependencies": {
+        "@arifwidianto/msa-core": "0.1.0",
+        "ws": "^8.17.0"
+      },
+      "devDependencies": {
+        "@types/ws": "^8.5.10",
+        "typescript": "^5.4.5"
+      },
+      "peerDependencies": {
+        "@arifwidianto/msa-core": "0.1.0"
+      }
+    },
+    "packages/plugin-messagebroker": {
+      "name": "@arifwidianto/msa-plugin-messagebroker",
+      "version": "0.1.0",
+      "dependencies": {
+        "@arifwidianto/msa-core": "0.1.0",
+        "amqplib": "^0.10.4",
+        "redis": "^4.6.13"
+      },
+      "devDependencies": {
+        "@types/amqplib": "^0.10.5",
+        "typescript": "^5.4.5"
+      },
+      "peerDependencies": {
+        "@arifwidianto/msa-core": "0.1.0"
       }
     },
     "packages/plugin-stdio": {
+      "name": "@arifwidianto/msa-plugin-stdio",
       "version": "0.1.0",
+      "dependencies": {
+        "inquirer": "^9.2.20",
+        "yargs": "^17.7.2"
+      },
       "devDependencies": {
+        "@arifwidianto/msa-core": "0.1.0",
+        "@types/inquirer": "^9.0.7",
+        "@types/yargs": "^17.0.32",
         "typescript": "^5.4.5"
+      },
+      "peerDependencies": {
+        "@arifwidianto/msa-core": "0.1.0"
+      }
+    },
+    "packages/plugin-stdio/node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "packages/plugin-stdio/node_modules/inquirer": {
+      "version": "9.3.7",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.3.7.tgz",
+      "integrity": "sha512-LJKFHCSeIRq9hanN14IlOtPSTe3lNES7TYDTE2xxdAy1LS5rYphajK1qtwvj3YmQXvvk0U2Vbmcni8P9EIQW9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/figures": "^1.0.3",
+        "ansi-escapes": "^4.3.2",
+        "cli-width": "^4.1.0",
+        "external-editor": "^3.1.0",
+        "mute-stream": "1.0.0",
+        "ora": "^5.4.1",
+        "run-async": "^3.0.0",
+        "rxjs": "^7.8.1",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/plugin-stdio/node_modules/mute-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "packages/plugin-stdio/node_modules/run-async": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
+      "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "packages/plugin-websocket": {
+      "name": "@arifwidianto/msa-plugin-websocket",
       "version": "0.1.0",
+      "dependencies": {
+        "ws": "^8.17.0"
+      },
       "devDependencies": {
+        "@arifwidianto/msa-core": "0.1.0",
+        "@types/ws": "^8.5.10",
         "typescript": "^5.4.5"
+      },
+      "peerDependencies": {
+        "@arifwidianto/msa-core": "0.1.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -3,9 +3,15 @@
   "private": true,
   "devDependencies": {
     "lerna": "^8.2.2",
-    "typescript": "^5.8.3"
+    "typescript": "^5.4.5",
+    "jest": "^29.7.0",
+    "@types/jest": "^29.5.12",
+    "ts-jest": "^29.1.2"
   },
   "workspaces": [
     "packages/*"
-  ]
+  ],
+  "scripts": {
+    "test": "jest"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "msa-framework-monorepo",
+  "name": "@arifwidianto/msa",
   "private": true,
   "devDependencies": {
     "lerna": "^8.2.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,16 @@
     "packages/*"
   ],
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage",
+    "build": "lerna run build --stream",
+    "clean": "lerna run clean --stream",
+    "dev": "lerna run dev --stream --parallel",
+    "lint": "lerna run lint --stream --parallel",
+    "prepare": "lerna run build",
+    "docs": "typedoc --options typedoc.json",
+    "release": "lerna publish",
+    "bootstrap": "lerna bootstrap"
   }
 }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,146 @@
+# MSA Core (@arifwidianto/msa-core)
+
+This is the core foundation package for the MSA (Microservice Architecture) framework. It provides essential interfaces, base classes, and utility functions that all other MSA packages build upon. The core package enables the plugin architecture that makes MSA flexible and adaptable to various service types.
+
+## Features
+
+* Plugin architecture with dependency management
+* Service lifecycle management
+* Standardized interfaces for plugins and transports
+* Logging utilities
+* Configuration management
+* Type definitions for common messaging patterns
+
+## Installation
+
+```bash
+npm install @arifwidianto/msa-core
+```
+
+## Quick Start
+
+```typescript
+import { Service, IPlugin } from '@arifwidianto/msa-core';
+
+// Create a new service
+const service = new Service();
+
+// Register plugins
+service.registerPlugin(myPlugin);
+
+// Initialize and start the service
+await service.initializeService({
+  'plugin-name': {
+    // Plugin-specific configuration
+  }
+});
+
+await service.startService();
+```
+
+## Core Interfaces
+
+### IPlugin
+
+The foundational interface that all plugins must implement:
+
+```typescript
+interface IPlugin {
+  name: string;
+  version: string;
+  dependencies: string[]; // Names of other plugins this plugin depends on
+  initialize(config: PluginConfig): Promise<void>;
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  cleanup(): Promise<void>;
+}
+```
+
+### ITransport
+
+Interface for plugins that handle message passing:
+
+```typescript
+interface ITransport {
+  listen(port: number | string): Promise<void>; 
+  send(message: Message): Promise<void>;
+  onMessage(handler: MessageHandler): void;
+  close(): Promise<void>;
+}
+```
+
+### IAgent
+
+Interface for implementing intelligent agent capabilities:
+
+```typescript
+interface IAgent {
+  name: string;
+  capabilities: AgentCapability[];
+  handleRequest(request: AgentRequest): Promise<AgentResponse>;
+  learn(data: any): Promise<void>;
+}
+```
+
+## Service Class
+
+The `Service` class is the main entry point for creating MSA applications:
+
+```typescript
+class Service {
+  registerPlugin(plugin: IPlugin): void;
+  getPlugin(name: string): IPlugin | undefined;
+  async initializeService(configs: Record<string, PluginConfig>): Promise<void>;
+  async startService(): Promise<void>;
+  async stopService(): Promise<void>;
+  async cleanupService(): Promise<void>;
+}
+```
+
+## Utilities
+
+### Logger
+
+Provides standardized logging across all MSA components:
+
+```typescript
+Logger.info('Informational message');
+Logger.debug('Debug message');
+Logger.warn('Warning message');
+Logger.error('Error message');
+```
+
+### Config
+
+Helps manage configuration with environment variables and defaults:
+
+```typescript
+const config = new Config('my-service', {
+  port: 3000,
+  debug: false
+});
+
+// Override with environment variables
+// MY_SERVICE_PORT=4000
+const port = config.get('port'); // Returns 4000
+```
+
+## Development
+
+```bash
+# Install dependencies
+npm install
+
+# Build the package
+npm run build
+
+# Run tests
+npm run test
+
+# Development mode with watch
+npm run dev
+```
+
+## API Documentation
+
+For complete API documentation, see the TypeScript definition files or generated documentation.

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+  displayName: 'core',
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/test/**/*.test.ts'],
+  globals: {
+    'ts-jest': {
+      // Correct path relative to the root jest.config.js for monorepo setup
+      // or make tsconfig discoverable from this file's location.
+      tsconfig: '<rootDir>/tsconfig.json' // This points to packages/core/tsconfig.json
+    }
+  },
+  // If 'msa-core' is an alias in tsconfig paths, map it for Jest
+  moduleNameMapper: {
+    '^@arifwidianto/msa-core$': '<rootDir>/src/index.ts' // Adjust if your src/index.ts is different
+  }
+};

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,9 +3,23 @@
   "version": "0.1.0",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc -p tsconfig.build.json"
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rimraf dist",
+    "dev": "tsc -p tsconfig.build.json --watch",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage",
+    "lint": "eslint src/**/*.ts",
+    "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "rimraf": "^5.0.5",
+    "jest": "^29.7.0",
+    "@types/jest": "^29.5.12",
+    "eslint": "^8.52.0",
+    "@typescript-eslint/eslint-plugin": "^6.9.1",
+    "@typescript-eslint/parser": "^6.9.1",
+    "ts-jest": "^29.1.2"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,13 +13,16 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "typescript": "^5.4.5",
-    "rimraf": "^5.0.5",
-    "jest": "^29.7.0",
     "@types/jest": "^29.5.12",
-    "eslint": "^8.52.0",
     "@typescript-eslint/eslint-plugin": "^6.9.1",
     "@typescript-eslint/parser": "^6.9.1",
-    "ts-jest": "^29.1.2"
+    "eslint": "^8.52.0",
+    "jest": "^29.7.0",
+    "rimraf": "^5.0.5",
+    "ts-jest": "^29.1.2",
+    "typescript": "^5.4.5"
+  },
+  "dependencies": {
+    "pino": "^9.7.0"
   }
 }

--- a/packages/core/src/Logger.ts
+++ b/packages/core/src/Logger.ts
@@ -32,3 +32,5 @@ export const Logger = {
   // A method to get the raw pino instance if needed for advanced configuration
   getInstance: () => logger, 
 };
+
+export type LoggerType = typeof logger;

--- a/packages/core/test/Config.test.ts
+++ b/packages/core/test/Config.test.ts
@@ -1,0 +1,57 @@
+import { Config } from '../src/Config';
+
+describe('Config', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules(); // Most important - it clears the cache
+    process.env = { ...OLD_ENV }; // Make a copy
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV; // Restore old environment
+  });
+
+  it('should get a value from environment variables', () => {
+    process.env.TEST_KEY = 'test_value';
+    expect(Config.get('TEST_KEY')).toBe('test_value');
+  });
+
+  it('should return default value if environment variable is not set', () => {
+    expect(Config.get('UNDEFINED_KEY', 'default')).toBe('default');
+  });
+
+  it('should return undefined if environment variable is not set and no default is provided', () => {
+    expect(Config.get('UNDEFINED_KEY_NO_DEFAULT')).toBeUndefined();
+  });
+
+  it('should parse boolean true string from environment variables', () => {
+    process.env.BOOL_KEY_TRUE = 'true';
+    expect(Config.get('BOOL_KEY_TRUE')).toBe(true);
+  });
+
+  it('should parse boolean false string from environment variables', () => {
+    process.env.BOOL_KEY_FALSE = 'false';
+    expect(Config.get('BOOL_KEY_FALSE')).toBe(false);
+  });
+
+  it('should parse numeric string from environment variables', () => {
+    process.env.NUM_KEY = '123.45';
+    expect(Config.get('NUM_KEY')).toBe(123.45);
+  });
+
+  it('should return string if it looks like a number but is not perfectly parsed', () => {
+    process.env.STRING_NUM_KEY = '123.45abc';
+    expect(Config.get('STRING_NUM_KEY')).toBe('123.45abc');
+  });
+
+  it('should prioritize environment variable over default value', () => {
+    process.env.PRIORITY_KEY = 'env_value';
+    expect(Config.get('PRIORITY_KEY', 'default_value')).toBe('env_value');
+  });
+
+  it('should handle empty string from environment variables', () => {
+    process.env.EMPTY_STRING_KEY = '';
+    expect(Config.get('EMPTY_STRING_KEY', 'default_value')).toBe('');
+  });
+});

--- a/packages/core/test/Logger.test.ts
+++ b/packages/core/test/Logger.test.ts
@@ -1,0 +1,106 @@
+// Import Logger and Config from their respective paths
+import { Logger } from '../src/Logger';
+import { Config } from '../src/Config';
+
+// Mock the Config module
+jest.mock('../src/Config', () => ({
+  Config: {
+    get: jest.fn(),
+  },
+}));
+
+// Mock pino and pino-pretty
+const mockPinoInstance = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  setBindings: jest.fn(), // Mock this method as it's called in Logger.ts
+};
+jest.mock('pino', () => jest.fn(() => mockPinoInstance));
+jest.mock('pino-pretty', () => jest.fn()); // Simple mock for pino-pretty
+
+
+describe('Logger', () => {
+  beforeEach(() => {
+    // Reset mocks before each test
+    jest.clearAllMocks();
+    // Default mock implementation for Config.get
+    (Config.get as jest.Mock).mockReturnValue('info'); // Default log level
+  });
+
+  it('should initialize pino with default log level if LOG_LEVEL is not set', () => {
+    require('../src/Logger'); // Re-require to trigger initialization
+    expect(Config.get).toHaveBeenCalledWith('LOG_LEVEL', 'info');
+    expect(require('pino')).toHaveBeenCalledWith(expect.objectContaining({
+      level: 'info',
+    }));
+  });
+
+  it('should initialize pino with LOG_LEVEL from Config', () => {
+    (Config.get as jest.Mock).mockReturnValue('debug');
+    require('../src/Logger'); // Re-require
+    expect(require('pino')).toHaveBeenCalledWith(expect.objectContaining({
+      level: 'debug',
+    }));
+  });
+
+  it('should call pino.info when Logger.info is called', () => {
+    Logger.info('Test info message', { data: 'some data' });
+    expect(mockPinoInstance.info).toHaveBeenCalledWith('Test info message', { data: 'some data' });
+  });
+
+  it('should call pino.warn when Logger.warn is called', () => {
+    Logger.warn('Test warn message', { data: 'warning data' });
+    expect(mockPinoInstance.warn).toHaveBeenCalledWith('Test warn message', { data: 'warning data' });
+  });
+
+  it('should call pino.error when Logger.error is called', () => {
+    Logger.error('Test error message', new Error('test error'));
+    expect(mockPinoInstance.error).toHaveBeenCalledWith('Test error message', new Error('test error'));
+  });
+
+  it('should call pino.debug when Logger.debug is called', () => {
+    Logger.debug('Test debug message', { detail: 'debug details' });
+    expect(mockPinoInstance.debug).toHaveBeenCalledWith('Test debug message', { detail: 'debug details' });
+  });
+
+  it('getInstance should return the pino instance', () => {
+    const instance = Logger.getInstance();
+    expect(instance).toBe(mockPinoInstance);
+  });
+
+  it('should attempt to use pino-pretty transport', () => {
+    require('../src/Logger');
+    expect(require('pino')).toHaveBeenCalledWith(expect.objectContaining({
+      transport: expect.objectContaining({
+        target: 'pino-pretty',
+      }),
+    }));
+  });
+
+  it('should fallback to default transport if pino-pretty is not found', () => {
+    // Simulate pino-pretty not being found
+    jest.doMock('pino-pretty', () => { throw new Error('Cannot find module'); });
+    
+    // We need to reset modules and re-require Logger for the new mock to take effect
+    jest.resetModules();
+    const FreshLogger = require('../src/Logger').Logger; // Get the Logger object
+    const pino = require('pino'); // Get the pino module
+
+    // Check if setBindings was called, indicating a fallback
+    // This part of the test is tricky because of how pino itself is structured
+    // and how the logger instance is created and potentially modified.
+    // The original code has a try-catch for require.resolve('pino-pretty')
+    // If it fails, it calls logger.setBindings({}) which seems to be an attempt to reset/clear transport.
+    // For this test, we primarily care that pino was initialized. The internal fallback logic is harder to assert directly
+    // without more invasive mocking or observing side effects not present in the current Logger structure.
+    
+    // A simple check: pino was still called
+    expect(pino).toHaveBeenCalled();
+    // And that our mocked setBindings was called on the instance pino returned
+    // This requires ensuring the instance pino() returns is the one we spy on.
+    // The current mock structure for pino ensures this.
+    expect(mockPinoInstance.setBindings).toHaveBeenCalledWith({}); // Check if it attempts to reset transport
+  });
+});

--- a/packages/core/test/Service.test.ts
+++ b/packages/core/test/Service.test.ts
@@ -1,0 +1,222 @@
+import { Service } from '../src/Service';
+import { IPlugin, PluginConfig, Logger } from '../src'; // Assuming index.ts exports Logger
+
+// Mock Logger to prevent actual logging and allow spying
+jest.mock('../src/Logger', () => ({
+  Logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+// Mock IPlugin
+const mockPlugin = (name: string, dependencies: string[] = []): IPlugin => ({
+  name,
+  version: '1.0.0',
+  dependencies,
+  initialize: jest.fn().mockResolvedValue(undefined),
+  start: jest.fn().mockResolvedValue(undefined),
+  stop: jest.fn().mockResolvedValue(undefined),
+  cleanup: jest.fn().mockResolvedValue(undefined),
+});
+
+describe('Service', () => {
+  let service: Service;
+  let plugin1: IPlugin;
+  let plugin2: IPlugin;
+
+  beforeEach(() => {
+    // Reset all mocks before each test
+    jest.clearAllMocks();
+    service = new Service();
+    plugin1 = mockPlugin('plugin1');
+    plugin2 = mockPlugin('plugin2', ['plugin1']);
+  });
+
+  describe('Plugin Registration', () => {
+    it('should register a plugin', () => {
+      service.registerPlugin(plugin1);
+      // @ts-ignore access private member for test
+      expect(service['plugins']).toContain(plugin1);
+      expect(Logger.info).toHaveBeenCalledWith(`Plugin "plugin1" registered.`);
+    });
+
+    it('should log a warning if a dependency is not yet registered', () => {
+      service.registerPlugin(plugin2); // plugin1 (dependency) is not registered yet
+      expect(Logger.warn).toHaveBeenCalledWith(
+        'Plugin "plugin2" depends on "plugin1", which is not registered or registered after this plugin.'
+      );
+      // @ts-ignore
+      expect(service['plugins']).toContain(plugin2); // Still registers
+    });
+
+    it('should not log a warning if dependency is already registered', () => {
+      service.registerPlugin(plugin1);
+      service.registerPlugin(plugin2); // plugin1 is now registered
+      expect(Logger.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('depends on "plugin1"')
+      );
+    });
+  });
+
+  describe('Service Lifecycle', () => {
+    const configs: Record<string, PluginConfig> = {
+      plugin1: { setting: 'value1' },
+      plugin2: { setting: 'value2' },
+    };
+
+    beforeEach(() => {
+      service.registerPlugin(plugin1);
+      service.registerPlugin(plugin2);
+    });
+
+    it('should initialize all registered plugins with their configs', async () => {
+      await service.initializeService(configs);
+      expect(plugin1.initialize).toHaveBeenCalledWith(configs.plugin1);
+      expect(plugin2.initialize).toHaveBeenCalledWith(configs.plugin2);
+      expect(Logger.info).toHaveBeenCalledWith('Initializing service...');
+      expect(Logger.info).toHaveBeenCalledWith('Initializing plugin "plugin1"...');
+      expect(Logger.info).toHaveBeenCalledWith('Plugin "plugin1" initialized.');
+      expect(Logger.info).toHaveBeenCalledWith('Service initialized.');
+    });
+
+    it('should initialize plugin with empty config if not provided', async () => {
+      await service.initializeService({});
+      expect(plugin1.initialize).toHaveBeenCalledWith({});
+    });
+    
+    it('should handle errors during plugin initialization', async () => {
+      const error = new Error('Init failed');
+      (plugin1.initialize as jest.Mock).mockRejectedValueOnce(error);
+      await service.initializeService(configs);
+      expect(Logger.error).toHaveBeenCalledWith(`Error initializing plugin "plugin1": ${error.message}`);
+      expect(plugin2.initialize).toHaveBeenCalled(); // Should continue with other plugins
+    });
+
+    it('should start all registered plugins', async () => {
+      await service.startService();
+      expect(plugin1.start).toHaveBeenCalled();
+      expect(plugin2.start).toHaveBeenCalled();
+      expect(Logger.info).toHaveBeenCalledWith('Starting service...');
+      expect(Logger.info).toHaveBeenCalledWith('Starting plugin "plugin1"...');
+      expect(Logger.info).toHaveBeenCalledWith('Plugin "plugin1" started.');
+      expect(Logger.info).toHaveBeenCalledWith('Service started.');
+    });
+
+    it('should handle errors during plugin start', async () => {
+        const error = new Error('Start failed');
+        (plugin1.start as jest.Mock).mockRejectedValueOnce(error);
+        await service.startService();
+        expect(Logger.error).toHaveBeenCalledWith(`Error starting plugin "plugin1": ${error.message}`);
+        expect(plugin2.start).toHaveBeenCalled(); // Should continue
+    });
+
+    it('should stop all registered plugins in reverse order', async () => {
+      await service.stopService();
+      expect(plugin2.stop).toHaveBeenCalled();
+      expect(plugin1.stop).toHaveBeenCalled();
+      // Check call order if Jest supports it easily or by tracking calls
+      const stopOrder = (Logger.info as jest.Mock).mock.calls.filter(
+        (call: any) => call[0].includes('Stopping plugin')
+      );
+      expect(stopOrder[0][0]).toBe('Stopping plugin "plugin2"...');
+      expect(stopOrder[1][0]).toBe('Stopping plugin "plugin1"...');
+      expect(Logger.info).toHaveBeenCalledWith('Service stopped.');
+    });
+
+    it('should handle errors during plugin stop', async () => {
+        const error = new Error('Stop failed');
+        (plugin2.stop as jest.Mock).mockRejectedValueOnce(error);
+        await service.stopService();
+        expect(Logger.error).toHaveBeenCalledWith(`Error stopping plugin "plugin2": ${error.message}`);
+        expect(plugin1.stop).toHaveBeenCalled(); // Should continue
+    });
+
+    it('should cleanup all registered plugins in reverse order', async () => {
+      await service.cleanupService();
+      expect(plugin2.cleanup).toHaveBeenCalled();
+      expect(plugin1.cleanup).toHaveBeenCalled();
+      const cleanupOrder = (Logger.info as jest.Mock).mock.calls.filter(
+        (call: any) => call[0].includes('Cleaning up plugin')
+      );
+      expect(cleanupOrder[0][0]).toBe('Cleaning up plugin "plugin2"...');
+      expect(cleanupOrder[1][0]).toBe('Cleaning up plugin "plugin1"...');
+      expect(Logger.info).toHaveBeenCalledWith('Service cleaned up.');
+      // @ts-ignore
+      expect(service['plugins']).toEqual([]); // Plugins should be cleared
+    });
+
+    it('should handle errors during plugin cleanup', async () => {
+        const error = new Error('Cleanup failed');
+        (plugin2.cleanup as jest.Mock).mockRejectedValueOnce(error);
+        await service.cleanupService();
+        expect(Logger.error).toHaveBeenCalledWith(`Error cleaning up plugin "plugin2": ${error.message}`);
+        expect(plugin1.cleanup).toHaveBeenCalled(); // Should continue
+    });
+  });
+
+  describe('Graceful Shutdown', () => {
+    let mockProcessOn: jest.SpyInstance;
+    let mockProcessExit: jest.SpyInstance;
+
+    beforeEach(() => {
+        // Spy on process.on and process.exit
+        mockProcessOn = jest.spyOn(process, 'on');
+        mockProcessExit = jest.spyOn(process, 'exit').mockImplementation((() => {}) as any); // Mock exit to prevent test runner from exiting
+        
+        // Re-create service to register new signal handlers with spies
+        service = new Service(); 
+        service.registerPlugin(plugin1);
+    });
+
+    afterEach(() => {
+        // Restore original process functions
+        mockProcessOn.mockRestore();
+        mockProcessExit.mockRestore();
+    });
+
+    it('should setup signal handlers for SIGINT and SIGTERM', () => {
+      expect(mockProcessOn).toHaveBeenCalledWith('SIGINT', expect.any(Function));
+      expect(mockProcessOn).toHaveBeenCalledWith('SIGTERM', expect.any(Function));
+    });
+
+    it('should call stopService and cleanupService on SIGINT', async () => {
+      // Find the SIGINT handler
+      const sigintHandler = mockProcessOn.mock.calls.find(call => call[0] === 'SIGINT')[1];
+      
+      // jest.spyOn(service, 'stopService'); // Does not work as service instance is different in handler
+      // jest.spyOn(service, 'cleanupService');
+
+      await sigintHandler(); // Call the handler
+
+      expect(Logger.info).toHaveBeenCalledWith('Received SIGINT. Starting graceful shutdown...');
+      // To test that stopService and cleanupService are called on the *correct instance* of service
+      // is tricky here because the instance used in the test is not the same as the one
+      // the handler closes over unless we expose the service instance or use other patterns.
+      // For now, we check if Logger recorded the events, implying methods were called.
+      expect(Logger.info).toHaveBeenCalledWith(expect.stringContaining('Stopping service...'));
+      expect(Logger.info).toHaveBeenCalledWith(expect.stringContaining('Cleaning up service...'));
+      expect(Logger.info).toHaveBeenCalledWith('Graceful shutdown completed. Exiting.');
+      expect(mockProcessExit).toHaveBeenCalledWith(0);
+    });
+    
+    it('should only allow one shutdown process at a time', async () => {
+        const sigtermHandler = mockProcessOn.mock.calls.find(call => call[0] === 'SIGTERM')[1];
+        
+        // Call once
+        const firstShutdown = sigtermHandler();
+        // Call again immediately
+        await sigtermHandler();
+
+        await firstShutdown; // Wait for the first one to complete its async operations
+
+        expect(Logger.info).toHaveBeenCalledWith('Received SIGTERM. Starting graceful shutdown...');
+        expect(Logger.info).toHaveBeenCalledWith('Shutdown already in progress. Received SIGTERM again.');
+        // Ensure shutdown sequence (stop, cleanup, exit) is logged/called only once effectively
+        expect((Logger.info as jest.Mock).mock.calls.filter(c => c[0] === 'Graceful shutdown completed. Exiting.').length).toBe(1);
+        expect(mockProcessExit).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/plugin-http/README.md
+++ b/packages/plugin-http/README.md
@@ -1,29 +1,68 @@
 # MSA HTTP Plugin (@arifwidianto/msa-plugin-http)
 
-This plugin provides an HTTP server transport for the MSA (Microservice Architecture) framework. It uses Express.js to create and manage an HTTP server, allowing other plugins or the main service to register routes and handle HTTP requests.
+This plugin provides an HTTP server transport for the MSA (Microservice Architecture) framework. It uses Express.js to create and manage an HTTP server, allowing services to expose RESTful APIs and web endpoints with minimal configuration.
 
 ## Features
 
-*   Starts and stops an HTTP server.
-*   Configurable port and host.
-*   Allows registration of Express.js-compatible routes.
-*   Basic JSON body parsing middleware included by default.
-*   Implements `IPlugin` and parts of `ITransport` from `@arifwidianto/msa-core`.
+* Complete Express.js server with middleware support
+* Configurable port and host settings
+* Simple route registration API
+* JSON parsing middleware included by default
+* Request logging for better debugging
+* Access to the underlying Express app for advanced configuration
+* Implements both `IPlugin` and `ITransport` interfaces
 
 ## Installation
 
-This plugin is typically used as part of an MSA framework monorepo. Ensure it's listed as a dependency in your service or application package.
+```bash
+npm install @arifwidianto/msa-plugin-http @arifwidianto/msa-core express
+```
+
+## Quick Start
+
+```typescript
+import { Service } from '@arifwidianto/msa-core';
+import { HttpPlugin } from '@arifwidianto/msa-plugin-http';
+import { Request, Response } from 'express';
+
+async function main() {
+  const service = new Service();
+  const httpPlugin = new HttpPlugin();
+  
+  service.registerPlugin(httpPlugin);
+  
+  await service.initializeService({
+    'msa-plugin-http': {
+      port: 3000,
+      host: 'localhost'
+    }
+  });
+  
+  // Register routes before starting the service
+  httpPlugin.registerRoute('get', '/api/hello', (req: Request, res: Response) => {
+    res.json({ message: 'Hello from MSA HTTP plugin!' });
+  });
+  
+  httpPlugin.registerRoute('post', '/api/echo', (req: Request, res: Response) => {
+    res.json({
+      received: req.body,
+      timestamp: new Date().toISOString()
+    });
+  });
+  
+  await service.startService();
+  console.log('HTTP server started on http://localhost:3000');
+}
+
+main().catch(console.error);
+```
 
 ## Configuration
 
-The `HttpPlugin` can be configured during the service initialization phase. The configuration is passed to its `initialize` method.
-
-### `HttpPluginConfig`
+The HTTP Plugin can be configured during service initialization:
 
 ```typescript
-import { PluginConfig } from '@arifwidianto/msa-core';
-
-export interface HttpPluginConfig extends PluginConfig {
+interface HttpPluginConfig {
   port: number;      // Required: The port number for the HTTP server to listen on.
   host?: string;    // Optional: The host address (e.g., '0.0.0.0' or 'localhost'). Defaults to 'localhost'.
 }
@@ -32,23 +71,12 @@ export interface HttpPluginConfig extends PluginConfig {
 ### Example Configuration
 
 ```typescript
-// In your main service setup
-import { Service } from '@arifwidianto/msa-core';
-import { HttpPlugin, HttpPluginConfig } from '@arifwidianto/msa-plugin-http';
-
-const service = new Service();
-const httpPlugin = new HttpPlugin();
-
-const pluginConfigs = {
+{
   'msa-plugin-http': {
-    port: 8080,
-    host: '0.0.0.0'
-  } as HttpPluginConfig
-};
-
-service.registerPlugin(httpPlugin);
-await service.initializeService(pluginConfigs);
-await service.startService();
+    port: 8080,          // Listen on port 8080
+    host: '0.0.0.0'      // Listen on all network interfaces
+  }
+}
 ```
 
 ## Basic Usage
@@ -86,13 +114,116 @@ if (expressApp) {
 }
 ```
 
-## ITransport Implementation Notes
+## API Reference
 
-While `HttpPlugin` implements `ITransport` from `@arifwidianto/msa-core`, some `ITransport` methods have specific interpretations in the context of an HTTP server:
+### registerRoute(method, path, handler)
 
-*   `listen(portOrPath)`: Configures the port the server will use when `start()` is called.
-*   `send(message)`: Not directly implemented for a server-focused plugin. Could be used if the plugin also needed to make outbound HTTP requests.
-*   `onMessage(handler)`: A generic message handler can be registered, but `registerRoute` is preferred for typical HTTP API development.
-*   `close()`: Equivalent to `stop()`.
+Registers an HTTP route with the Express app:
 
-This plugin focuses on providing the server-side HTTP capabilities.
+```typescript
+import { Request, Response } from 'express';
+
+// Register a GET endpoint
+httpPlugin.registerRoute('get', '/api/users', (req: Request, res: Response) => {
+  const users = [{ id: 1, name: 'User 1' }, { id: 2, name: 'User 2' }];
+  res.json(users);
+});
+
+// Register a POST endpoint with request body
+httpPlugin.registerRoute('post', '/api/users', (req: Request, res: Response) => {
+  const newUser = req.body;
+  // Process new user data
+  res.status(201).json({ id: 3, ...newUser });
+});
+```
+
+Supported HTTP methods:
+- `get`
+- `post`
+- `put`
+- `delete`
+- `patch`
+- `options`
+- `head`
+- `all`
+
+### getExpressApp()
+
+Access the underlying Express app for advanced configuration:
+
+```typescript
+const expressApp = httpPlugin.getExpressApp();
+if (expressApp) {
+  // Add custom middleware
+  expressApp.use('/static', express.static('public'));
+  
+  // Add global error handler
+  expressApp.use((err, req, res, next) => {
+    console.error(err.stack);
+    res.status(500).json({ error: 'Something went wrong!' });
+  });
+}
+```
+
+## Adding Custom Middleware
+
+You can add custom middleware to the Express app using the `getExpressApp()` method:
+
+```typescript
+import { Service } from '@arifwidianto/msa-core';
+import { HttpPlugin } from '@arifwidianto/msa-plugin-http';
+import express from 'express';
+import cors from 'cors';
+import helmet from 'helmet';
+
+async function main() {
+  const service = new Service();
+  const httpPlugin = new HttpPlugin();
+  
+  service.registerPlugin(httpPlugin);
+  await service.initializeService({ 'msa-plugin-http': { port: 3000 } });
+  
+  // Add custom middleware
+  const app = httpPlugin.getExpressApp();
+  if (app) {
+    // CORS support
+    app.use(cors());
+    
+    // Security headers
+    app.use(helmet());
+    
+    // Custom logging
+    app.use((req, res, next) => {
+      console.log(`${req.method} ${req.url} - ${new Date().toISOString()}`);
+      next();
+    });
+  }
+  
+  await service.startService();
+}
+```
+
+## ITransport Implementation
+
+The HTTP plugin implements `ITransport` with the following behavior:
+
+- `listen(port)`: Configures the port the server will use when `start()` is called.
+- `send(message)`: Not typically used for a server plugin but could be extended to make outbound HTTP requests.
+- `onMessage(handler)`: A generic message handler can be registered, but `registerRoute` is generally preferred.
+- `close()`: Equivalent to `stop()` - closes the HTTP server.
+
+## Development
+
+```bash
+# Install dependencies
+npm install
+
+# Build the package
+npm run build
+
+# Run tests
+npm run test
+
+# Development mode with watch
+npm run dev
+```

--- a/packages/plugin-http/jest.config.js
+++ b/packages/plugin-http/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  displayName: 'plugin-http',
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/test/**/*.test.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.json'
+    }
+  },
+  moduleNameMapper: {
+    '^@arifwidianto/msa-core$': '<rootDir>/../core/src/index.ts' // Adjust path based on actual structure
+  }
+};

--- a/packages/plugin-http/package.json
+++ b/packages/plugin-http/package.json
@@ -3,12 +3,28 @@
   "version": "0.1.0",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc -p tsconfig.build.json"
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rimraf dist",
+    "dev": "tsc -p tsconfig.build.json --watch",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage",
+    "lint": "eslint src/**/*.ts",
+    "prepublishOnly": "npm run build"
   },
   "devDependencies": {
     "typescript": "^5.4.5",
     "@arifwidianto/msa-core": "0.1.0",
-    "@types/express": "^4.17.21"
+    "@types/express": "^4.17.21",
+    "rimraf": "^5.0.5",
+    "jest": "^29.7.0",
+    "@types/jest": "^29.5.12",
+    "eslint": "^8.52.0",
+    "@typescript-eslint/eslint-plugin": "^6.9.1",
+    "@typescript-eslint/parser": "^6.9.1",
+    "ts-jest": "^29.1.2",
+    "supertest": "^6.3.4",
+    "@types/supertest": "^6.0.2"
   },
   "peerDependencies": {
     "@arifwidianto/msa-core": "0.1.0"

--- a/packages/plugin-http/src/HttpPlugin.ts
+++ b/packages/plugin-http/src/HttpPlugin.ts
@@ -127,14 +127,7 @@ export class HttpPlugin implements IPlugin, ITransport {
     if (!this.app) {
       throw new Error('HTTP Plugin: Not initialized. Cannot register route.');
     }
-    const supportedMethods = [
-      'get', 'post', 'put', 'delete', 'patch', 'options', 'head', 'all'
-    ];
-    const methodLower = method.toLowerCase();
-    if (!supportedMethods.includes(methodLower)) {
-      throw new Error(`HTTP Plugin: Unsupported HTTP method "${method}". Supported methods are: ${supportedMethods.join(', ')}`);
-    }
-    const router = (this.app as any)[methodLower];
+    const router = (this.app as any)[method.toLowerCase()];
     if (!router) {
       throw new Error(`HTTP Plugin: Invalid HTTP method "${method}".`);
     }

--- a/packages/plugin-http/src/HttpPlugin.ts
+++ b/packages/plugin-http/src/HttpPlugin.ts
@@ -118,10 +118,21 @@ export class HttpPlugin implements IPlugin, ITransport {
   // --- HTTP Specific Methods ---
 
   /**
-   * Registers an HTTP route.
-   * @param method HTTP method (e.g., 'get', 'post')
-   * @param path Route path (e.g., '/users')
-   * @param handler Express RequestHandler
+   * Registers a new HTTP route with the specified method, path, and handler.
+   * 
+   * @param method - The HTTP method to use (e.g., 'get', 'post', 'put', 'delete', 'patch').
+   *                 Any method that exists as a property on the Express app object will be accepted.
+   *                 Case-insensitive (will be converted to lowercase).
+   * @param path - The URL path pattern to match for this route.
+   * @param handler - The function that will handle requests to this route.
+   * @throws {Error} If the plugin is not initialized or if the HTTP method is invalid
+   *                 (i.e., not available as a method on the Express app object).
+   * 
+   * @remarks
+   * Note that this method doesn't perform explicit validation against a whitelist of
+   * supported HTTP methods. It will attempt to use any method name that matches a property
+   * on the Express app object, which could lead to unexpected behavior if method names
+   * contain typos or reference unsupported methods.
    */
   public registerRoute(method: string, path: string, handler: RequestHandler): void {
     if (!this.app) {

--- a/packages/plugin-http/test/HttpPlugin.test.ts
+++ b/packages/plugin-http/test/HttpPlugin.test.ts
@@ -1,0 +1,204 @@
+import { HttpPlugin, HttpPluginConfig } from '../src';
+import { Logger } from '@arifwidianto/msa-core'; // Assuming this path is correct
+import http from 'http';
+
+// Mock Logger
+jest.mock('@arifwidianto/msa-core', () => {
+  const originalModule = jest.requireActual('@arifwidianto/msa-core');
+  return {
+    ...originalModule, // Spread original module exports
+    Logger: { // Mock Logger specifically
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    },
+  };
+});
+
+
+// Mock express and http.Server
+const mockExpressApp = {
+  use: jest.fn(),
+  listen: jest.fn(),
+  get: jest.fn(), // For registerRoute
+  post: jest.fn(),
+  // Add other HTTP methods if your registerRoute supports them
+};
+const mockHttpServer = {
+  listen: jest.fn(),
+  close: jest.fn(),
+  on: jest.fn(),
+  address: jest.fn().mockReturnValue({ port: 3000, address: '127.0.0.1' }),
+};
+
+jest.mock('express', () => jest.fn(() => mockExpressApp));
+jest.spyOn(http, 'createServer').mockImplementation(() => mockHttpServer as any); // If HttpPlugin uses http.createServer(app)
+// If HttpPlugin directly uses app.listen which returns its own server:
+// Need to ensure app.listen returns our mockHttpServer
+(mockExpressApp.listen as jest.Mock).mockImplementation((port, host, callback) => {
+  callback(); // Simulate immediate listen
+  return mockHttpServer;
+});
+
+
+describe('HttpPlugin', () => {
+  let plugin: HttpPlugin;
+  const defaultConfig: HttpPluginConfig = { port: 3000, host: 'localhost' };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    plugin = new HttpPlugin();
+  });
+
+  describe('Initialization', () => {
+    it('should initialize with default config if none provided', async () => {
+      // Note: HttpPlugin's internal default is { port: 3000 }, not defaultConfig from test
+      await plugin.initialize({}); 
+      expect(Logger.info).toHaveBeenCalledWith(expect.stringContaining('initialized with config: {"port":3000}'));
+      expect(require('express')).toHaveBeenCalled();
+      expect(mockExpressApp.use).toHaveBeenCalledWith(expect.any(Function)); // For express.json()
+      expect(mockExpressApp.use).toHaveBeenCalledWith(expect.any(Function)); // For logging middleware
+    });
+
+    it('should initialize with provided config', async () => {
+      const config: HttpPluginConfig = { port: 8080, host: '0.0.0.0' };
+      await plugin.initialize(config);
+      expect(Logger.info).toHaveBeenCalledWith(expect.stringContaining(JSON.stringify(config)));
+    });
+
+    it('should throw error if port is not configured (e.g. explicitly set to 0 or undefined)', async () => {
+        // This test depends on how the plugin handles a "missing" port.
+        // If port can be undefined in PluginConfig and HttpPluginConfig makes it mandatory
+        // then the type system should help. If it can be 0 or falsy:
+        await expect(plugin.initialize({ port: 0 } as any)).rejects.toThrow('HTTP Plugin: Port must be configured.');
+    });
+  });
+
+  describe('Start/Stop', () => {
+    beforeEach(async () => {
+      await plugin.initialize(defaultConfig);
+    });
+
+    it('should start the HTTP server', async () => {
+      await plugin.start();
+      expect(mockExpressApp.listen).toHaveBeenCalledWith(
+        defaultConfig.port,
+        defaultConfig.host,
+        expect.any(Function)
+      );
+      expect(Logger.info).toHaveBeenCalledWith(expect.stringContaining(`Listening on ${defaultConfig.host}:${defaultConfig.port}`));
+    });
+
+    it('should throw error if start is called before initialize', async () => {
+      const newPlugin = new HttpPlugin(); // Uninitialized plugin
+      await expect(newPlugin.start()).rejects.toThrow('HTTP Plugin: Not initialized. Call initialize() first.');
+    });
+
+    it('should stop the HTTP server', async () => {
+      await plugin.start(); // Start first
+      (mockHttpServer.close as jest.Mock).mockImplementationOnce((callback) => callback()); // Simulate server closing
+      await plugin.stop();
+      expect(mockHttpServer.close).toHaveBeenCalled();
+      expect(Logger.info).toHaveBeenCalledWith(expect.stringContaining('stopped.'));
+    });
+    
+    it('should resolve if stop is called when server is not running', async () => {
+        await plugin.stop(); // Server not started or already stopped
+        expect(Logger.info).toHaveBeenCalledWith(expect.stringContaining('was not running.'));
+        expect(mockHttpServer.close).not.toHaveBeenCalled();
+    });
+
+    it('should handle server error on start', async () => {
+        const error = new Error('Listen EADDRINUSE');
+        (mockExpressApp.listen as jest.Mock).mockImplementationOnce((p, h, c) => {
+            // Simulate error event being emitted by the server object returned by app.listen
+            // This requires that app.listen indeed returns an object on which 'error' can be emitted
+            // And that object is our mockHttpServer
+            process.nextTick(() => mockHttpServer.on.mock.calls.find(c => c[0] === 'error')[1](error));
+            return mockHttpServer;
+        });
+        await expect(plugin.start()).rejects.toThrow(error.message);
+        expect(Logger.error).toHaveBeenCalledWith(expect.stringContaining(`failed to start: ${error.message}`));
+    });
+  });
+
+  describe('Route Registration', () => {
+    beforeEach(async () => {
+      await plugin.initialize(defaultConfig);
+    });
+
+    it('should register a GET route', () => {
+      const handler = jest.fn();
+      plugin.registerRoute('get', '/test', handler);
+      expect(mockExpressApp.get).toHaveBeenCalledWith('/test', handler);
+      expect(Logger.info).toHaveBeenCalledWith('HTTP Plugin: Route registered: GET /test');
+    });
+
+    it('should register a POST route', () => {
+      const handler = jest.fn();
+      plugin.registerRoute('post', '/submit', handler);
+      expect(mockExpressApp.post).toHaveBeenCalledWith('/submit', handler);
+      expect(Logger.info).toHaveBeenCalledWith('HTTP Plugin: Route registered: POST /submit');
+    });
+
+    it('should throw error if registering route before initialization', () => {
+      const newPlugin = new HttpPlugin();
+      const handler = jest.fn();
+      expect(() => newPlugin.registerRoute('get', '/test', handler)).toThrow('HTTP Plugin: Not initialized. Cannot register route.');
+    });
+    
+    it('should throw error for invalid HTTP method', () => {
+        const handler = jest.fn();
+        expect(() => plugin.registerRoute('invalid', '/test', handler)).toThrow('HTTP Plugin: Invalid HTTP method "invalid".');
+    });
+  });
+
+  describe('ITransport methods', () => {
+    beforeEach(async () => {
+      await plugin.initialize(defaultConfig);
+    });
+
+    it('listen() should update config port and log', async () => {
+        await plugin.listen(8888);
+        // @ts-ignore access private member for test
+        expect(plugin['config'].port).toBe(8888);
+        await plugin.listen("9999");
+        // @ts-ignore
+        expect(plugin['config'].port).toBe(9999);
+        await plugin.listen("invalid_port"); // Should warn and keep existing port
+        // @ts-ignore
+        expect(plugin['config'].port).toBe(9999); // Stays 9999
+        expect(Logger.warn).toHaveBeenCalledWith(expect.stringContaining("Invalid port/path for listen: invalid_port"));
+    });
+
+    it('send() should log a warning as it is not implemented for server', async () => {
+        await plugin.send({ data: "test" });
+        expect(Logger.warn).toHaveBeenCalledWith('HTTP Plugin: ITransport.send() is not meaningfully implemented for a server-focused HTTP plugin.');
+    });
+
+    it('onMessage() should register a generic handler and log', () => {
+        const handler = jest.fn();
+        plugin.onMessage(handler);
+        // @ts-ignore
+        expect(plugin['messageHandler']).toBe(handler);
+        expect(Logger.info).toHaveBeenCalledWith(expect.stringContaining("Generic message handler registered"));
+    });
+    
+    it('close() should call stop', async () => {
+        const stopSpy = jest.spyOn(plugin, 'stop');
+        await plugin.close();
+        expect(stopSpy).toHaveBeenCalled();
+    });
+  });
+  
+  describe('Cleanup', () => {
+    it('should nullify the app instance', async () => {
+        await plugin.initialize(defaultConfig);
+        expect(plugin.getExpressApp()).not.toBeNull();
+        await plugin.cleanup();
+        expect(plugin.getExpressApp()).toBeNull();
+        expect(Logger.info).toHaveBeenCalledWith(expect.stringContaining('cleaned up.'));
+    });
+  });
+});

--- a/packages/plugin-langchain/README.md
+++ b/packages/plugin-langchain/README.md
@@ -1,0 +1,157 @@
+# MSA Langchain Plugin (@arifwidianto/msa-plugin-langchain)
+
+This plugin integrates Langchain capabilities into the MSA (Microservice Architecture) framework, allowing services to easily leverage Large Language Models (LLMs) for various tasks. It provides a configurable interface to interact with LLMs, primarily using OpenAI models through `@langchain/openai`.
+
+## Features
+
+*   Initializes a Langchain LLM client (currently `ChatOpenAI`).
+*   Configurable API keys and default model names.
+*   Provides a simple method `invokeChain` to run LLM chains with prompt templates.
+*   Provides a `chat` method for direct conversational interactions with the LLM.
+*   Implements `IPlugin` from `@arifwidianto/msa-core`.
+
+## Installation
+
+This plugin is typically used as part of an MSA framework monorepo. Ensure it's listed as a dependency in your service or application package. The necessary Langchain dependencies (`langchain`, `@langchain/openai`) should be automatically managed if using Lerna or npm/yarn workspaces.
+
+```bash
+# If managing dependencies manually within a package that uses this plugin:
+npm install langchain @langchain/openai @arifwidianto/msa-plugin-langchain @arifwidianto/msa-core
+# or
+yarn add langchain @langchain/openai @arifwidianto/msa-plugin-langchain @arifwidianto/msa-core
+```
+
+## Configuration
+
+The `LangchainPlugin` is configured during the service initialization phase. The configuration is passed to its `initialize` method.
+
+### `LangchainPluginConfig`
+
+```typescript
+import { PluginConfig } from '@arifwidianto/msa-core';
+
+export interface LangchainPluginConfig extends PluginConfig {
+  apiKey: string;           // Required: Your OpenAI API key.
+  defaultModelName?: string; // Optional: The default OpenAI model to use (e.g., "gpt-4", "gpt-3.5-turbo").
+                           // Defaults to "gpt-3.5-turbo" within the plugin.
+  // Other provider-specific configurations can be added here.
+}
+```
+
+### Environment Variables
+
+It's highly recommended to provide the API key via environment variables rather than hardcoding it in configuration files. The `Config` class from `@arifwidianto/msa-core` can be used to fetch this.
+
+Example: Set `OPENAI_API_KEY="your_api_key_here"` in your environment.
+
+### Example Service Setup
+
+```typescript
+// In your main service setup
+import { Service, Config, Logger } from '@arifwidianto/msa-core';
+import { LangchainPlugin, LangchainPluginConfig } from '@arifwidianto/msa-plugin-langchain';
+
+const service = new Service();
+const langchainPlugin = new LangchainPlugin();
+
+const pluginConfigs = {
+  [langchainPlugin.name]: { // Use plugin.name for the key
+    apiKey: Config.get('OPENAI_API_KEY'), // Fetch from environment
+    defaultModelName: 'gpt-4-turbo-preview'
+  } as LangchainPluginConfig
+};
+
+// Ensure API key is found
+if (!pluginConfigs[langchainPlugin.name].apiKey) {
+  Logger.error("OpenAI API Key not found in environment variable OPENAI_API_KEY. LangchainPlugin will not work.");
+  // Handle missing key appropriately, perhaps by not registering or starting the plugin, or exiting.
+} else {
+  service.registerPlugin(langchainPlugin);
+}
+
+// Initialize and start the service
+// await service.initializeService(pluginConfigs);
+// await service.startService();
+// Now langchainPlugin methods can be called.
+```
+
+## Basic Usage
+
+### Invoking a Chain
+
+The `invokeChain` method allows you to execute a prompt against the configured LLM.
+
+```typescript
+// Assuming langchainPlugin is an initialized instance of LangchainPlugin
+
+async function summarizeText(textToSummarize: string) {
+  const prompt = "Please provide a concise summary of the following text:\n{text}";
+  const inputs = { text: textToSummarize };
+
+  try {
+    const summary = await langchainPlugin.invokeChain(prompt, inputs);
+    Logger.info(`Summary: ${summary}`);
+    return summary;
+  } catch (error) {
+    Logger.error(`Error getting summary: ${error}`);
+    throw error;
+  }
+}
+
+// summarizeText("Some long text here...");
+```
+
+You can also pass a `PromptTemplate` instance:
+```typescript
+import { PromptTemplate } from "@langchain/core/prompts";
+
+// ...
+const PTemplate = new PromptTemplate({template: "Tell me a joke about {topic}.", inputVariables: ["topic"]});
+const joke = await langchainPlugin.invokeChain(PTemplate, { topic: "programmers" });
+Logger.info(`Joke: ${joke}`);
+// ...
+```
+
+### Chatting with the LLM
+
+The `chat` method allows for conversational interactions.
+
+```typescript
+// Assuming langchainPlugin is an initialized instance of LangchainPlugin
+
+async function askQuestion(question: string) {
+  const messages = [
+    { role: 'system' as const, content: 'You are a helpful assistant that answers questions accurately.' },
+    { role: 'user' as const, content: question },
+  ];
+
+  try {
+    const answer = await langchainPlugin.chat(messages);
+    Logger.info(`AI Answer: ${answer}`);
+    return answer;
+  } catch (error) {
+    Logger.error(`Error getting chat response: ${error}`);
+    throw error;
+  }
+}
+
+// askQuestion("What is the capital of France?");
+```
+
+### Direct LLM Access
+
+For more advanced scenarios, you can get the underlying Langchain LLM instance:
+
+```typescript
+const llmInstance = langchainPlugin.getLLM();
+if (llmInstance) {
+  // Use llmInstance directly with Langchain's more advanced features
+  // For example, llmInstance.generatePrompt(...) or llmInstance.stream(...)
+}
+```
+
+## LLM Provider
+
+This plugin currently uses `@langchain/openai` and is configured for OpenAI models. To use other LLM providers supported by Langchain (e.g., Anthropic, Cohere, local models via Ollama), the `LangchainPlugin.ts` would need to be modified to support different LLM client initializations and configurations.
+
+This plugin provides a foundational layer for integrating Langchain into your MSA services. You can build more complex AI-driven features by leveraging these basic interaction patterns.

--- a/packages/plugin-langchain/jest.config.js
+++ b/packages/plugin-langchain/jest.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+  displayName: 'plugin-langchain',
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/test/**/*.test.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.json' // This should point to packages/plugin-langchain/tsconfig.json
+    }
+  },
+  moduleNameMapper: {
+    // If you use path aliases in tsconfig.json that Jest needs to understand
+    // e.g., "^@core/(.*)$": "<rootDir>/../core/src/$1"
+    // For this plugin, we need to ensure it can find @arifwidianto/msa-core
+    '^@arifwidianto/msa-core$': '<rootDir>/../core/src/index.ts'
+  }
+};

--- a/packages/plugin-langchain/package.json
+++ b/packages/plugin-langchain/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@arifwidianto/msa-plugin-langchain",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json"
+  },
+  "dependencies": {
+    "langchain": "^0.1.36",
+    "@langchain/openai": "^0.0.28"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5",
+    "@arifwidianto/msa-core": "0.1.0"
+  },
+  "peerDependencies": {
+    "@arifwidianto/msa-core": "0.1.0"
+  }
+}

--- a/packages/plugin-langchain/package.json
+++ b/packages/plugin-langchain/package.json
@@ -4,15 +4,30 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc -p tsconfig.build.json"
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rimraf dist",
+    "dev": "tsc -p tsconfig.build.json --watch",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage",
+    "lint": "eslint src/**/*.ts",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "langchain": "^0.1.36",
-    "@langchain/openai": "^0.0.28"
+    "@langchain/openai": "^0.0.28",
+    "@langchain/core": "^0.1.30",
+    "@arifwidianto/msa-core": "0.1.0"
   },
   "devDependencies": {
     "typescript": "^5.4.5",
-    "@arifwidianto/msa-core": "0.1.0"
+    "rimraf": "^5.0.5",
+    "jest": "^29.7.0",
+    "@types/jest": "^29.5.12",
+    "eslint": "^8.52.0",
+    "@typescript-eslint/eslint-plugin": "^6.9.1",
+    "@typescript-eslint/parser": "^6.9.1",
+    "ts-jest": "^29.1.2"
   },
   "peerDependencies": {
     "@arifwidianto/msa-core": "0.1.0"

--- a/packages/plugin-langchain/src/LangchainPlugin.ts
+++ b/packages/plugin-langchain/src/LangchainPlugin.ts
@@ -1,33 +1,69 @@
-import { IPlugin, Logger } from '@arifwidianto/msa-core';
+import { IPlugin, Logger, ITransport, Message, MessageHandler } from '@arifwidianto/msa-core';
 import { LangchainPluginConfig } from './LangchainPluginConfig';
 import { ChatOpenAI } from '@langchain/openai';
 import { LLMChain } from 'langchain/chains';
 import { PromptTemplate, ChatPromptTemplate, SystemMessagePromptTemplate, HumanMessagePromptTemplate } from '@langchain/core/prompts';
 import { BaseMessage, HumanMessage, AIMessage, SystemMessage } from '@langchain/core/messages';
 
-export class LangchainPlugin implements IPlugin {
+export class LangchainPlugin implements IPlugin, ITransport {
   public readonly name = 'msa-plugin-langchain';
   public readonly version = '0.1.0';
   public readonly dependencies: string[] = [];
 
-  private config: LangchainPluginConfig = { apiKey: '' }; // Default to empty, must be configured
+  private config: LangchainPluginConfig = { provider: 'openai', auth: { apiKey: '' } }; // Default to empty, must be configured
   private llm: ChatOpenAI | null = null;
 
   public async initialize(config: LangchainPluginConfig): Promise<void> {
     this.config = { ...this.config, ...config };
 
-    if (!this.config.apiKey) {
+    if (!this.config.auth.apiKey) {
       Logger.error(`${this.name}: API key is required but not provided.`);
       throw new Error(`${this.name}: API key is missing in plugin configuration.`);
     }
 
     try {
-      this.llm = new ChatOpenAI({
-        apiKey: this.config.apiKey,
+      // Base configuration for the LLM
+      const llmConfig: any = {
+        apiKey: this.config.auth.apiKey,
         modelName: this.config.defaultModelName || 'gpt-3.5-turbo', // Default model
         temperature: 0.7, // Default temperature, can be made configurable
-      });
-      Logger.info(`${this.name}: ChatOpenAI client initialized successfully with model ${this.llm.modelName}.`);
+      };
+
+      // Handle provider-specific configuration
+      switch (this.config.provider.toLowerCase()) {
+        case 'azure':
+          if (!this.config.providerOptions?.azure) {
+            throw new Error(`${this.name}: Azure provider requires providerOptions.azure configuration`);
+          }
+          
+          const azureConfig = this.config.providerOptions.azure;
+          llmConfig.azureOpenAIApiKey = this.config.auth.apiKey;
+          llmConfig.azureOpenAIApiVersion = azureConfig.apiVersion;
+          llmConfig.azureOpenAIApiInstanceName = azureConfig.instanceName;
+          llmConfig.azureOpenAIApiDeploymentName = azureConfig.deploymentName;
+          break;
+          
+        case 'openai':
+          // Add any OpenAI specific configurations
+          if (this.config.providerOptions?.openai?.organization) {
+            llmConfig.organization = this.config.providerOptions.openai.organization;
+          }
+          break;
+
+        case 'anthropic':
+          // Could implement Anthropic client initialization
+          throw new Error(`${this.name}: Provider '${this.config.provider}' is configured but not yet implemented`);
+
+        case 'gemini':
+          // Could implement Google's Gemini client initialization
+          throw new Error(`${this.name}: Provider '${this.config.provider}' is configured but not yet implemented`);
+          
+        default:
+          throw new Error(`${this.name}: Unknown LLM provider '${this.config.provider}'`);
+      }
+      
+      this.llm = new ChatOpenAI(llmConfig);
+      Logger.info(`${this.name}: ChatOpenAI client initialized successfully with model ${this.llm.modelName} using ${this.config.provider} provider.`);
     } catch (error) {
       Logger.error(`${this.name}: Failed to initialize ChatOpenAI client: ${error instanceof Error ? error.message : String(error)}`);
       throw error; // Re-throw the error to signal initialization failure
@@ -53,36 +89,38 @@ export class LangchainPlugin implements IPlugin {
       throw new Error(`${this.name}: LLM not initialized.`);
     }
 
-    let PTemplate: PromptTemplate;
+    let prompt: PromptTemplate;
     if (typeof promptTemplate === 'string') {
-      // Infer input variables from string - this is a simplistic approach
-      // Langchain's PromptTemplate.fromTemplate does this better.
-      const inputVariables = (promptTemplate.match(/{[^}]+}/g) || []).map(v => v.slice(1, -1));
-      PTemplate = new PromptTemplate({ template: promptTemplate, inputVariables });
+      prompt = PromptTemplate.fromTemplate(promptTemplate);
     } else {
-      PTemplate = promptTemplate;
+      prompt = promptTemplate;
     }
     
     try {
-      const chain = new LLMChain({ llm: this.llm, prompt: PTemplate });
-      Logger.debug(`${this.name}: Invoking LLMChain with inputs: ${JSON.stringify(inputs)}`);
+      // Using LCEL (Langchain Expression Language)
+      const chain = prompt.pipe(this.llm);
+      Logger.debug(`${this.name}: Invoking LLM chain with inputs: ${JSON.stringify(inputs)}`);
       const result = await chain.invoke(inputs);
 
-      // The result structure from LLMChain can vary. Typically, it's { text: "response" }
-      // or other keys if the prompt or chain is more complex.
-      if (typeof result.text === 'string') {
-        Logger.debug(`${this.name}: LLMChain invocation successful. Response: ${result.text}`);
-        return result.text;
-      } else if (typeof result === 'string') { // Sometimes the result itself is the string
-        Logger.debug(`${this.name}: LLMChain invocation successful. Response: ${result}`);
+      // Handle different response formats
+      if (typeof result === 'string') {
+        Logger.debug(`${this.name}: LLM chain invocation successful. Response: ${result}`);
         return result;
+      } else if (result?.content && typeof result.content === 'string') {
+        // AIMessage response with content property
+        Logger.debug(`${this.name}: LLM chain invocation successful. Response content: ${result.content}`);
+        return result.content;
+      } else if (typeof result?.text === 'string') {
+        // Legacy format with text property
+        Logger.debug(`${this.name}: LLM chain invocation successful. Response text: ${result.text}`);
+        return result.text;
       } else {
-        Logger.warn(`${this.name}: LLMChain response format unexpected. Full result: ${JSON.stringify(result)}`);
-        // Attempt to find a string in the response, or stringify the whole thing
-        return result.output || result.text || JSON.stringify(result);
+        Logger.warn(`${this.name}: LLM chain response format unexpected. Full result: ${JSON.stringify(result)}`);
+        // Attempt to stringify the whole result if none of the above formats match
+        return JSON.stringify(result);
       }
     } catch (error) {
-      Logger.error(`${this.name}: Error invoking LLMChain: ${error instanceof Error ? error.message : String(error)}`);
+      Logger.error(`${this.name}: Error invoking LLM chain: ${error instanceof Error ? error.message : String(error)}`);
       throw error;
     }
   }
@@ -129,5 +167,54 @@ export class LangchainPlugin implements IPlugin {
 
   public getLLM(): ChatOpenAI | null {
     return this.llm;
+  }
+
+  // ITransport implementation
+  public async listen(portOrPath: number | string): Promise<void> {
+    Logger.info(`${this.name}: listen() called with port/path: ${portOrPath}`);
+    // For LangchainPlugin, listen doesn't apply directly but we implement it for interface compliance
+    // We could use this to set up a local server for model inference if needed in the future
+  }
+
+  public async send(message: Message): Promise<void> {
+    Logger.info(`${this.name}: send() called with message: ${JSON.stringify(message)}`);
+    
+    // If message is a string or has content property, we can process it as a prompt
+    let promptContent: string;
+    if (typeof message === 'string') {
+      promptContent = message;
+    } else if (message && typeof message.content === 'string') {
+      promptContent = message.content;
+    } else {
+      // Attempt to stringify any other message format
+      promptContent = JSON.stringify(message);
+    }
+    
+    // Use the LLM to process the message if initialized
+    if (this.llm) {
+      try {
+        const response = await this.llm.invoke(promptContent);
+        // The response handling is done by the caller of this method
+        Logger.debug(`${this.name}: Message processed successfully by LLM`);
+      } catch (error) {
+        Logger.error(`${this.name}: Error processing message with LLM: ${error instanceof Error ? error.message : String(error)}`);
+        throw error;
+      }
+    } else {
+      Logger.error(`${this.name}: Cannot process message, LLM not initialized`);
+      throw new Error(`${this.name}: LLM not initialized`);
+    }
+  }
+
+  public onMessage(handler: MessageHandler): void {
+    Logger.info(`${this.name}: onMessage() handler registered.`);
+    // For Langchain plugin, we don't receive external messages directly as it's a provider
+    // rather than a consumer, but we implement the method for interface compliance
+  }
+  
+  public async close(): Promise<void> {
+    Logger.info(`${this.name}: close() called`);
+    // Release any resources that need to be explicitly closed
+    return this.cleanup();
   }
 }

--- a/packages/plugin-langchain/src/LangchainPlugin.ts
+++ b/packages/plugin-langchain/src/LangchainPlugin.ts
@@ -1,0 +1,133 @@
+import { IPlugin, Logger } from '@arifwidianto/msa-core';
+import { LangchainPluginConfig } from './LangchainPluginConfig';
+import { ChatOpenAI } from '@langchain/openai';
+import { LLMChain } from 'langchain/chains';
+import { PromptTemplate, ChatPromptTemplate, SystemMessagePromptTemplate, HumanMessagePromptTemplate } from '@langchain/core/prompts';
+import { BaseMessage, HumanMessage, AIMessage, SystemMessage } from '@langchain/core/messages';
+
+export class LangchainPlugin implements IPlugin {
+  public readonly name = 'msa-plugin-langchain';
+  public readonly version = '0.1.0';
+  public readonly dependencies: string[] = [];
+
+  private config: LangchainPluginConfig = { apiKey: '' }; // Default to empty, must be configured
+  private llm: ChatOpenAI | null = null;
+
+  public async initialize(config: LangchainPluginConfig): Promise<void> {
+    this.config = { ...this.config, ...config };
+
+    if (!this.config.apiKey) {
+      Logger.error(`${this.name}: API key is required but not provided.`);
+      throw new Error(`${this.name}: API key is missing in plugin configuration.`);
+    }
+
+    try {
+      this.llm = new ChatOpenAI({
+        apiKey: this.config.apiKey,
+        modelName: this.config.defaultModelName || 'gpt-3.5-turbo', // Default model
+        temperature: 0.7, // Default temperature, can be made configurable
+      });
+      Logger.info(`${this.name}: ChatOpenAI client initialized successfully with model ${this.llm.modelName}.`);
+    } catch (error) {
+      Logger.error(`${this.name}: Failed to initialize ChatOpenAI client: ${error instanceof Error ? error.message : String(error)}`);
+      throw error; // Re-throw the error to signal initialization failure
+    }
+  }
+
+  public async start(): Promise<void> {
+    Logger.info(`${this.name}: start() called. No specific start actions required for this plugin.`);
+  }
+
+  public async stop(): Promise<void> {
+    Logger.info(`${this.name}: stop() called. No specific stop actions required for this plugin.`);
+  }
+
+  public async cleanup(): Promise<void> {
+    Logger.info(`${this.name}: cleanup() called. Releasing resources.`);
+    this.llm = null; // Allow garbage collection
+  }
+
+  public async invokeChain(promptTemplate: string | PromptTemplate, inputs: Record<string, any>): Promise<string> {
+    if (!this.llm) {
+      Logger.error(`${this.name}: LLM not initialized. Cannot invoke chain.`);
+      throw new Error(`${this.name}: LLM not initialized.`);
+    }
+
+    let PTemplate: PromptTemplate;
+    if (typeof promptTemplate === 'string') {
+      // Infer input variables from string - this is a simplistic approach
+      // Langchain's PromptTemplate.fromTemplate does this better.
+      const inputVariables = (promptTemplate.match(/{[^}]+}/g) || []).map(v => v.slice(1, -1));
+      PTemplate = new PromptTemplate({ template: promptTemplate, inputVariables });
+    } else {
+      PTemplate = promptTemplate;
+    }
+    
+    try {
+      const chain = new LLMChain({ llm: this.llm, prompt: PTemplate });
+      Logger.debug(`${this.name}: Invoking LLMChain with inputs: ${JSON.stringify(inputs)}`);
+      const result = await chain.invoke(inputs);
+
+      // The result structure from LLMChain can vary. Typically, it's { text: "response" }
+      // or other keys if the prompt or chain is more complex.
+      if (typeof result.text === 'string') {
+        Logger.debug(`${this.name}: LLMChain invocation successful. Response: ${result.text}`);
+        return result.text;
+      } else if (typeof result === 'string') { // Sometimes the result itself is the string
+        Logger.debug(`${this.name}: LLMChain invocation successful. Response: ${result}`);
+        return result;
+      } else {
+        Logger.warn(`${this.name}: LLMChain response format unexpected. Full result: ${JSON.stringify(result)}`);
+        // Attempt to find a string in the response, or stringify the whole thing
+        return result.output || result.text || JSON.stringify(result);
+      }
+    } catch (error) {
+      Logger.error(`${this.name}: Error invoking LLMChain: ${error instanceof Error ? error.message : String(error)}`);
+      throw error;
+    }
+  }
+
+  public async chat(messages: Array<{ role: 'user' | 'system' | 'ai'; content: string }>): Promise<string> {
+    if (!this.llm) {
+      Logger.error(`${this.name}: LLM not initialized. Cannot perform chat.`);
+      throw new Error(`${this.name}: LLM not initialized.`);
+    }
+
+    const langChainMessages: BaseMessage[] = messages.map(msg => {
+      switch (msg.role) {
+        case 'user':
+          return new HumanMessage({ content: msg.content });
+        case 'ai':
+          return new AIMessage({ content: msg.content });
+        case 'system':
+          return new SystemMessage({ content: msg.content });
+        default:
+          // Should not happen with typed input, but good for robustness
+          Logger.warn(`${this.name}: Unknown message role encountered: ${msg.role}. Treating as user message.`);
+          return new HumanMessage({ content: msg.content });
+      }
+    });
+
+    try {
+      Logger.debug(`${this.name}: Invoking chat model with messages: ${JSON.stringify(messages)}`);
+      const response = await this.llm.invoke(langChainMessages);
+      if (typeof response.content === 'string') {
+         Logger.debug(`${this.name}: Chat invocation successful. Response: ${response.content}`);
+        return response.content;
+      } else {
+        // Langchain AIMessage content can be string | MessageContentComplex[]
+        // For simplicity, we'll stringify if not a simple string.
+        const responseContent = JSON.stringify(response.content);
+        Logger.debug(`${this.name}: Chat invocation successful. Complex response content: ${responseContent}`);
+        return responseContent;
+      }
+    } catch (error) {
+      Logger.error(`${this.name}: Error during chat invocation: ${error instanceof Error ? error.message : String(error)}`);
+      throw error;
+    }
+  }
+
+  public getLLM(): ChatOpenAI | null {
+    return this.llm;
+  }
+}

--- a/packages/plugin-langchain/src/LangchainPluginConfig.ts
+++ b/packages/plugin-langchain/src/LangchainPluginConfig.ts
@@ -1,0 +1,11 @@
+import { PluginConfig } from '@arifwidianto/msa-core';
+
+export interface LangchainPluginConfig extends PluginConfig {
+  apiKey: string; // Generic name, can be specific like openAIApiKey
+  defaultModelName?: string;
+  // Add other relevant Langchain provider specific configs
+  // For example, if using Azure OpenAI:
+  // azureOpenAIApiVersion?: string;
+  // azureOpenAIApiInstanceName?: string;
+  // azureOpenAIApiDeploymentName?: string;
+}

--- a/packages/plugin-langchain/src/LangchainPluginConfig.ts
+++ b/packages/plugin-langchain/src/LangchainPluginConfig.ts
@@ -1,11 +1,27 @@
 import { PluginConfig } from '@arifwidianto/msa-core';
 
 export interface LangchainPluginConfig extends PluginConfig {
-  apiKey: string; // Generic name, can be specific like openAIApiKey
+  /** Which LLM provider to use (openai, azure, anthropic, gemini, etc.) */
+  provider: string;
+
+  /** Optional default model name for the chosen provider */
   defaultModelName?: string;
-  // Add other relevant Langchain provider specific configs
-  // For example, if using Azure OpenAI:
-  // azureOpenAIApiVersion?: string;
-  // azureOpenAIApiInstanceName?: string;
-  // azureOpenAIApiDeploymentName?: string;
+
+  /** Authentication credentials for the selected provider */
+  auth: {
+    apiKey: string;
+    // add token, secret, or other auth fields as needed
+  };
+
+  /** Provider-specific options (e.g., Azure API version/deployment, OpenAI org, Anthropic safety settings) */
+  providerOptions?: {
+    openai?: { organization?: string };
+    azure?: {
+      apiVersion: string;
+      instanceName: string;
+      deploymentName: string;
+    };
+    anthropic?: { /* safety settings, model version */ };
+    // add other providers here
+  };
 }

--- a/packages/plugin-langchain/src/index.ts
+++ b/packages/plugin-langchain/src/index.ts
@@ -1,0 +1,2 @@
+export { LangchainPlugin } from './LangchainPlugin';
+export { LangchainPluginConfig } from './LangchainPluginConfig';

--- a/packages/plugin-langchain/test/LangchainPlugin.test.ts
+++ b/packages/plugin-langchain/test/LangchainPlugin.test.ts
@@ -6,18 +6,14 @@ import { PromptTemplate } from '@langchain/core/prompts';
 import { HumanMessage, AIMessage, SystemMessage, BaseMessage } from '@langchain/core/messages';
 
 // Mock Logger from @arifwidianto/msa-core
-jest.mock('@arifwidianto/msa-core', () => {
-  const originalModule = jest.requireActual('@arifwidianto/msa-core');
-  return {
-    ...originalModule,
-    Logger: {
-      info: jest.fn(),
-      warn: jest.fn(),
-      error: jest.fn(),
-      debug: jest.fn(),
-    },
-  };
-});
+jest.mock('@arifwidianto/msa-core', () => ({
+  Logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
 
 // Mock @langchain/openai
 const mockChatOpenAIInstance = {
@@ -46,7 +42,10 @@ jest.mock('@langchain/core/prompts', () => ({
 describe('LangchainPlugin', () => {
   let plugin: LangchainPlugin;
   const defaultConfig: LangchainPluginConfig = {
-    apiKey: 'test-api-key',
+    provider: 'openai',
+    auth: {
+      apiKey: 'test-api-key'
+    },
     defaultModelName: 'gpt-test',
   };
 
@@ -59,7 +58,7 @@ describe('LangchainPlugin', () => {
     it('should initialize ChatOpenAI with provided API key and model name', async () => {
       await plugin.initialize(defaultConfig);
       expect(ChatOpenAI).toHaveBeenCalledWith({
-        apiKey: defaultConfig.apiKey,
+        apiKey: defaultConfig.auth.apiKey,
         modelName: defaultConfig.defaultModelName,
         temperature: 0.7, // Default or configured temperature
       });
@@ -68,7 +67,10 @@ describe('LangchainPlugin', () => {
     });
 
     it('should use default model name if not provided in config', async () => {
-      const configNoModel: LangchainPluginConfig = { apiKey: 'test-api-key' };
+      const configNoModel: LangchainPluginConfig = { 
+        provider: 'openai',
+        auth: { apiKey: 'test-api-key' }
+      };
       await plugin.initialize(configNoModel);
       expect(ChatOpenAI).toHaveBeenCalledWith(expect.objectContaining({
         modelName: 'gpt-3.5-turbo', // Internal default
@@ -76,7 +78,10 @@ describe('LangchainPlugin', () => {
     });
 
     it('should throw error if API key is not provided', async () => {
-      const configNoApi: LangchainPluginConfig = { apiKey: '' };
+      const configNoApi: LangchainPluginConfig = { 
+        provider: 'openai',
+        auth: { apiKey: '' }
+      };
       await expect(plugin.initialize(configNoApi)).rejects.toThrow(
         `${plugin.name}: API key is missing in plugin configuration.`
       );

--- a/packages/plugin-langchain/test/LangchainPlugin.test.ts
+++ b/packages/plugin-langchain/test/LangchainPlugin.test.ts
@@ -1,0 +1,197 @@
+import { LangchainPlugin, LangchainPluginConfig } from '../src';
+import { Logger } from '@arifwidianto/msa-core';
+import { ChatOpenAI } from '@langchain/openai';
+import { LLMChain } from 'langchain/chains';
+import { PromptTemplate } from '@langchain/core/prompts';
+import { HumanMessage, AIMessage, SystemMessage, BaseMessage } from '@langchain/core/messages';
+
+// Mock Logger from @arifwidianto/msa-core
+jest.mock('@arifwidianto/msa-core', () => {
+  const originalModule = jest.requireActual('@arifwidianto/msa-core');
+  return {
+    ...originalModule,
+    Logger: {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    },
+  };
+});
+
+// Mock @langchain/openai
+const mockChatOpenAIInstance = {
+  invoke: jest.fn(),
+  modelName: 'mock-gpt-3.5-turbo',
+};
+jest.mock('@langchain/openai', () => ({
+  ChatOpenAI: jest.fn(() => mockChatOpenAIInstance),
+}));
+
+// Mock langchain/chains
+const mockLLMChainInstance = {
+  invoke: jest.fn(),
+};
+jest.mock('langchain/chains', () => ({
+  LLMChain: jest.fn(() => mockLLMChainInstance),
+}));
+
+// Mock @langchain/core/prompts (if specific methods like fromTemplate are used internally)
+// For now, we assume PromptTemplate is instantiated directly or its methods are not critical to mock for these tests
+jest.mock('@langchain/core/prompts', () => ({
+  PromptTemplate: jest.fn((params) => ({ ...params, format: jest.fn() })), // Simple mock
+}));
+
+
+describe('LangchainPlugin', () => {
+  let plugin: LangchainPlugin;
+  const defaultConfig: LangchainPluginConfig = {
+    apiKey: 'test-api-key',
+    defaultModelName: 'gpt-test',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    plugin = new LangchainPlugin();
+  });
+
+  describe('Initialization', () => {
+    it('should initialize ChatOpenAI with provided API key and model name', async () => {
+      await plugin.initialize(defaultConfig);
+      expect(ChatOpenAI).toHaveBeenCalledWith({
+        apiKey: defaultConfig.apiKey,
+        modelName: defaultConfig.defaultModelName,
+        temperature: 0.7, // Default or configured temperature
+      });
+      expect(Logger.info).toHaveBeenCalledWith(expect.stringContaining('ChatOpenAI client initialized successfully'));
+      expect(plugin.getLLM()).toBe(mockChatOpenAIInstance);
+    });
+
+    it('should use default model name if not provided in config', async () => {
+      const configNoModel: LangchainPluginConfig = { apiKey: 'test-api-key' };
+      await plugin.initialize(configNoModel);
+      expect(ChatOpenAI).toHaveBeenCalledWith(expect.objectContaining({
+        modelName: 'gpt-3.5-turbo', // Internal default
+      }));
+    });
+
+    it('should throw error if API key is not provided', async () => {
+      const configNoApi: LangchainPluginConfig = { apiKey: '' };
+      await expect(plugin.initialize(configNoApi)).rejects.toThrow(
+        `${plugin.name}: API key is missing in plugin configuration.`
+      );
+      expect(Logger.error).toHaveBeenCalledWith(expect.stringContaining('API key is required'));
+    });
+    
+    it('should handle errors during ChatOpenAI client initialization', async () => {
+        const initError = new Error("Failed to connect");
+        (ChatOpenAI as jest.Mock).mockImplementationOnce(() => { throw initError; });
+        await expect(plugin.initialize(defaultConfig)).rejects.toThrow(initError);
+        expect(Logger.error).toHaveBeenCalledWith(expect.stringContaining(`Failed to initialize ChatOpenAI client: ${initError.message}`));
+    });
+  });
+
+  describe('invokeChain', () => {
+    beforeEach(async () => {
+      await plugin.initialize(defaultConfig);
+    });
+
+    it('should invoke LLMChain with given prompt and inputs, returning text', async () => {
+      const promptTemplate = 'Translate {text} to {language}.';
+      const inputs = { text: 'hello', language: 'French' };
+      const mockResponse = { text: 'bonjour' };
+      (mockLLMChainInstance.invoke as jest.Mock).mockResolvedValueOnce(mockResponse);
+
+      const result = await plugin.invokeChain(promptTemplate, inputs);
+
+      expect(PromptTemplate).toHaveBeenCalledWith({
+        template: promptTemplate,
+        inputVariables: ['text', 'language'], // Inferred by the plugin
+      });
+      expect(LLMChain).toHaveBeenCalledWith({
+        llm: mockChatOpenAIInstance,
+        prompt: expect.any(Object), // The mocked PromptTemplate instance
+      });
+      expect(mockLLMChainInstance.invoke).toHaveBeenCalledWith(inputs);
+      expect(result).toBe(mockResponse.text);
+    });
+    
+    it('should use PromptTemplate instance directly if provided', async () => {
+        const PTemplate = new PromptTemplate({template: "Q: {question}", inputVariables: ["question"]});
+        const inputs = { question: "What is AI?" };
+        const mockResponse = { text: "AI is..." };
+        (mockLLMChainInstance.invoke as jest.Mock).mockResolvedValueOnce(mockResponse);
+
+        await plugin.invokeChain(PTemplate, inputs);
+        expect(LLMChain).toHaveBeenCalledWith(expect.objectContaining({ prompt: PTemplate }));
+        expect(mockLLMChainInstance.invoke).toHaveBeenCalledWith(inputs);
+    });
+
+    it('should throw error if LLM is not initialized', async () => {
+      const uninitializedPlugin = new LangchainPlugin(); // No initialize call
+      await expect(uninitializedPlugin.invokeChain('prompt', {})).rejects.toThrow('LLM not initialized.');
+    });
+    
+    it('should handle LLMChain error', async () => {
+        const error = new Error("LLMChain failed");
+        (mockLLMChainInstance.invoke as jest.Mock).mockRejectedValueOnce(error);
+        await expect(plugin.invokeChain("Test", {})).rejects.toThrow(error);
+        expect(Logger.error).toHaveBeenCalledWith(expect.stringContaining(`Error invoking LLMChain: ${error.message}`));
+    });
+  });
+
+  describe('chat', () => {
+    beforeEach(async () => {
+      await plugin.initialize(defaultConfig);
+    });
+
+    it('should invoke chat model with formatted messages and return AI content', async () => {
+      const messages = [
+        { role: 'system' as const, content: 'You are helpful.' },
+        { role: 'user' as const, content: 'Hello AI.' },
+      ];
+      const mockResponseContent = 'Hello user!';
+      (mockChatOpenAIInstance.invoke as jest.Mock).mockResolvedValueOnce(new AIMessage(mockResponseContent));
+
+      const result = await plugin.chat(messages);
+
+      expect(mockChatOpenAIInstance.invoke).toHaveBeenCalledWith([
+        expect.any(SystemMessage), // Or use expect.objectContaining({ content: 'You are helpful.'})
+        expect.any(HumanMessage),  // Or use expect.objectContaining({ content: 'Hello AI.'})
+      ]);
+      expect(result).toBe(mockResponseContent);
+    });
+
+    it('should throw error if LLM is not initialized for chat', async () => {
+      const uninitializedPlugin = new LangchainPlugin();
+      await expect(uninitializedPlugin.chat([])).rejects.toThrow('LLM not initialized.');
+    });
+    
+    it('should handle chat model error', async () => {
+        const error = new Error("Chat failed");
+        (mockChatOpenAIInstance.invoke as jest.Mock).mockRejectedValueOnce(error);
+        await expect(plugin.chat([])).rejects.toThrow(error);
+        expect(Logger.error).toHaveBeenCalledWith(expect.stringContaining(`Error during chat invocation: ${error.message}`));
+    });
+  });
+
+  describe('Lifecycle Methods (start, stop, cleanup)', () => {
+    it('start() should log info and do nothing else', async () => {
+      await plugin.start();
+      expect(Logger.info).toHaveBeenCalledWith(`${plugin.name}: start() called. No specific start actions required for this plugin.`);
+    });
+
+    it('stop() should log info and do nothing else', async () => {
+      await plugin.stop();
+      expect(Logger.info).toHaveBeenCalledWith(`${plugin.name}: stop() called. No specific stop actions required for this plugin.`);
+    });
+
+    it('cleanup() should log info and nullify LLM', async () => {
+      await plugin.initialize(defaultConfig); // Initialize to have an LLM instance
+      expect(plugin.getLLM()).not.toBeNull();
+      await plugin.cleanup();
+      expect(Logger.info).toHaveBeenCalledWith(`${plugin.name}: cleanup() called. Releasing resources.`);
+      expect(plugin.getLLM()).toBeNull();
+    });
+  });
+});

--- a/packages/plugin-langchain/tsconfig.build.json
+++ b/packages/plugin-langchain/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
+  "exclude": ["node_modules", "dist", "test"]
+}

--- a/packages/plugin-langchain/tsconfig.json
+++ b/packages/plugin-langchain/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["src"]
+}

--- a/packages/plugin-langchain/tsconfig.json
+++ b/packages/plugin-langchain/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "outDir": "./dist"
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }

--- a/packages/plugin-mcp/README.md
+++ b/packages/plugin-mcp/README.md
@@ -1,0 +1,257 @@
+# MSA MCP Plugin (@arifwidianto/msa-plugin-mcp)
+
+This plugin provides client and server implementations for the Model Context Protocol (MCP) within the MSA (Microservice Architecture) framework. It allows MSA services to connect to an MCP server (as a client) or act as an MCP server itself, facilitating standardized message exchange for interacting with models or other context-aware services. MCP communication typically occurs over WebSockets.
+
+## Features
+
+*   **MCPClient**: A WebSocket client to connect to an MCP server.
+    *   Manages connection lifecycle (connect, close).
+    *   Sends MCP-formatted requests and handles responses.
+    *   Supports pending request tracking and timeouts.
+    *   Handles server-initiated messages via a configurable handler.
+    *   Includes auto-reconnection logic with configurable attempts and intervals.
+*   **MCPServer**: An MCP server component.
+    *   Integrates with an existing `ITransport` plugin (e.g., `msa-plugin-websocket`) to listen for incoming MCP messages.
+    *   Allows registration of action handlers to process MCP requests.
+    *   Generates and sends MCP-formatted responses.
+*   **MCPPlugin**: An `IPlugin` implementation that wraps both `MCPClient` and `MCPServer`.
+    *   Initializes and manages the lifecycle of `MCPClient` (if client mode is configured) and `MCPServer` (if server mode is enabled).
+    *   Provides easy access to client and server instances.
+*   **MCP Data Structures**: Defines TypeScript interfaces for MCP messages (`MCPRequest`, `MCPResponse`, etc.).
+
+## Installation
+
+This plugin is typically used as part of an MSA framework monorepo. Ensure it's listed as a dependency in your service or application package. The necessary dependencies (`ws`, `@arifwidianto/msa-core`) should be automatically managed.
+
+```bash
+# If managing dependencies manually:
+npm install ws @arifwidianto/msa-plugin-mcp @arifwidianto/msa-core
+# or
+yarn add ws @arifwidianto/msa-plugin-mcp @arifwidianto/msa-core
+```
+
+## Configuration
+
+The `MCPPlugin` is configured during the service initialization phase. It supports separate configurations for client and server modes.
+
+### `MCPPluginConfig`
+
+```typescript
+import { PluginConfig } from '@arifwidianto/msa-core';
+
+// Configuration for MCP Server mode
+export interface MCPServerConfig {
+  enabled: boolean; // To enable server mode
+  // port?: number; // Not directly used if relying on a transport plugin like WebSocketPlugin
+  // host?: string; // Not directly used if relying on a transport plugin
+  // path?: string; // Path configuration should be handled by the underlying WebSocket transport plugin
+  transportPluginName?: string; // Required: Name of the transport plugin to use (e.g., 'msa-plugin-websocket')
+}
+
+// Main configuration for MCPPlugin
+export interface MCPPluginConfig extends PluginConfig {
+  client?: { // Client mode configuration
+    serverUrl: string; // Required: The WebSocket URL of the MCP server to connect to.
+    autoReconnectClient?: boolean;      // Optional: Defaults to true in MCPClient.
+    maxReconnectAttemptsClient?: number; // Optional: Defaults to 5 in MCPClient.
+    reconnectIntervalClient?: number;   // Optional: Defaults to 5000ms in MCPClient.
+  };
+  server?: MCPServerConfig; // Server mode configuration
+}
+```
+
+### Environment Variables
+
+It's recommended to provide sensitive or environment-specific configurations (like `serverUrl` for the client) via environment variables, using `@arifwidianto/msa-core`'s `Config` class.
+
+Example: Set `MCP_CLIENT_SERVER_URL="ws://some-mcp-server:8080/mcp"` for client mode.
+
+### Example Service Setup
+
+```typescript
+// In your main service setup
+import { Service, Config, Logger, ITransport } from '@arifwidianto/msa-core';
+import { MCPPlugin, MCPPluginConfig, MCPRequestHandler, MCPRequest, MCPContext, MCPResponse } from '@arifwidianto/msa-plugin-mcp';
+import { WebSocketPlugin, WebSocketPluginConfig } from '@arifwidianto/msa-plugin-websocket'; // Assuming WebSocket transport
+
+const service = new Service();
+
+// Instantiate plugins
+const mcpPlugin = new MCPPlugin();
+const wsPlugin = new WebSocketPlugin(); // Transport plugin for the MCP server
+
+// Register plugins with the service
+service.registerPlugin(wsPlugin); // Register transport first
+service.registerPlugin(mcpPlugin);
+
+// Configuration
+const pluginConfigs = {
+  [wsPlugin.name]: { // Configuration for WebSocketPlugin
+    port: 8080,
+    host: '0.0.0.0',
+    // path: '/mcp' // Optional: if you want MCP server on a specific path
+  } as WebSocketPluginConfig,
+
+  [mcpPlugin.name]: {
+    client: { // Example client configuration (optional)
+      serverUrl: Config.get('MCP_ANOTHER_SERVER_URL'), // If this service also acts as a client to another MCP server
+    },
+    server: { // Example server configuration
+      enabled: true,
+      transportPluginName: wsPlugin.name, // Crucial: Link to the WebSocket transport plugin
+    }
+  } as MCPPluginConfig
+};
+
+// Initialize and start the service
+async function main() {
+  // It's assumed MCPPlugin.initialize is modified to accept the Service instance or a core access object
+  // to retrieve other plugins and the logger. For this example, we'll assume a hypothetical
+  // `service.initializePlugins(pluginConfigs)` that handles inter-plugin dependencies.
+  // The MCPPlugin's initialize method would then look up the transport plugin.
+
+  // For MCPServer to work, the MCPPlugin needs access to the transport instance.
+  // This might be handled by the service's initialization logic, e.g.:
+  // service.initializeService(pluginConfigs, { 
+  //   getService: () => service, 
+  //   getPlugin: (name) => service.getPlugin(name), // Simplified
+  //   getLogger: (context) => Logger // Simplified 
+  // });
+  // Or, more simply, if MCPPlugin's initialize is called manually with the transport:
+  
+  if (pluginConfigs[mcpPlugin.name].server?.enabled) {
+      const transport = service.getPlugin<ITransport>(pluginConfigs[mcpPlugin.name].server!.transportPluginName!);
+      if (transport) {
+          await mcpPlugin.initialize(pluginConfigs[mcpPlugin.name], transport);
+      } else {
+          Logger.error("Failed to get transport for MCP Server.");
+          return; // Exit or handle error
+      }
+  } else if (pluginConfigs[mcpPlugin.name].client?.serverUrl) {
+      await mcpPlugin.initialize(pluginConfigs[mcpPlugin.name]);
+  }
+
+
+  await service.startService(); // Starts WebSocket server and attempts MCPClient connection if configured
+
+  // --- MCP Server: Register Action Handlers ---
+  if (mcpPlugin.getServer()) { // Check if server was initialized
+    const exampleActionHandler: MCPRequestHandler = async (request: MCPRequest, context: MCPContext) => {
+      Logger.info({ msg: 'MCP Server: Handling exampleAction', request });
+      // Process the request...
+      return {
+        payload: { result: `Action '${request.action}' processed successfully for data: ${JSON.stringify(request.payload)}` },
+        // status: 'success', // Optional, defaults to success
+        // context: { ...context, newInfo: 'added_by_handler' } // Optional: update context
+      };
+    };
+    mcpPlugin.registerServerAction('exampleAction', exampleActionHandler);
+    Logger.info("MCP Server: 'exampleAction' handler registered.");
+  }
+
+  // --- MCP Client: Send Request (if client is configured and connected) ---
+  if (mcpPlugin.getClient() && pluginConfigs[mcpPlugin.name].client?.serverUrl) {
+    try {
+      const client = mcpPlugin.getClient();
+      // Ensure client is connected (startService should attempt this)
+      // For a robust check: if (client.getReadyState() === WebSocket.OPEN) { ... }
+      Logger.info("MCP Client: Attempting to send 'exampleAction' to remote server...");
+      const response = await client.sendRequest('exampleAction', { data: "Hello from client!" });
+      Logger.info({ msg: "MCP Client: Received response from remote server", response });
+    } catch (error) {
+      Logger.error({ msg: "MCP Client: Error sending request or processing response", error });
+    }
+  }
+}
+
+main().catch(error => Logger.error({ msg: "Service failed to start or run", error }));
+```
+
+## Client Mode Usage
+
+If `config.client.serverUrl` is provided, the plugin initializes an `MCPClient`.
+
+### Getting the Client
+
+```typescript
+// Assuming mcpPlugin is an initialized instance of MCPPlugin
+const client: MCPClient = mcpPlugin.getClient();
+```
+
+### Sending a Request
+
+The `sendRequest` method sends an MCP request to the server and returns a promise that resolves with the `MCPResponse`.
+
+```typescript
+import { MCPRequest, MCPResponse, MCPContext } from '@arifwidianto/msa-plugin-mcp'; // Import types
+import { Logger } from '@arifwidianto/msa-core';
+
+async function performClientAction(action: string, payload: any) {
+  try {
+    const client = mcpPlugin.getClient(); // Get client instance
+    const context: MCPContext = { sessionId: "clientSession789" };
+    Logger.info(`MCP Client: Sending MCP request for action: ${action}`);
+    
+    const response: MCPResponse = await client.sendRequest(action, payload, context);
+
+    if (response.status === 'success') {
+      Logger.info(`MCP Client: Action "${action}" successful. Payload: ${JSON.stringify(response.payload)}`);
+      return response.payload;
+    } else {
+      // ... error handling ...
+    }
+  } catch (error) {
+    // ... error handling ...
+  }
+}
+```
+
+### Handling Server-Initiated Messages (Client)
+
+The client can receive messages not directly in response to its requests.
+```typescript
+client.setOnMessageHandler((message: MCPMessage) => {
+  Logger.info(`MCP Client: Received server-initiated message: Type: ${message.type}, ID: ${message.messageId}`);
+  // Process message
+});
+```
+
+## Server Mode Usage
+
+If `config.server.enabled` is true and `config.server.transportPluginName` is provided, the plugin initializes an `MCPServer`.
+
+### Registering Action Handlers
+
+The core of the server functionality is handling actions.
+```typescript
+import { MCPRequestHandler, MCPRequest, MCPContext } from '@arifwidianto/msa-plugin-mcp';
+import { Logger } from '@arifwidianto/msa-core';
+
+const myActionHandler: MCPRequestHandler = async (request: MCPRequest, context: MCPContext) => {
+  Logger.info(`MCP Server: Handling action '${request.action}' with payload:`, request.payload);
+  // Business logic here...
+  if (request.payload.value > 100) {
+    return {
+      status: 'error',
+      error: { code: 'VALUE_TOO_HIGH', message: 'Value cannot exceed 100' }
+    };
+  }
+  return {
+    payload: { processedValue: request.payload.value * 2, message: "Successfully processed by server." },
+    context: { ...context, processedTimestamp: new Date().toISOString() } // Optionally update context
+  };
+};
+
+// Assuming mcpPlugin is initialized and server mode is enabled
+if (mcpPlugin.getServer()) {
+    mcpPlugin.registerServerAction('processData', myActionHandler);
+    Logger.info("MCP Server: 'processData' handler registered.");
+}
+```
+The `MCPServer` receives raw messages from the specified transport plugin (e.g., `msa-plugin-websocket`), parses them as MCP messages, invokes the appropriate handler, and sends the response back via the transport.
+
+### Transport Integration
+
+The `MCPServer` relies on an `ITransport` plugin (like `msa-plugin-websocket`) for actual network communication. The `MCPPlugin` must be configured with the name of this transport plugin, and the core `Service` is responsible for providing the instance of this transport to the `MCPPlugin` during initialization. The lifecycle (start, stop) of the transport is managed by its own plugin and the core `Service`.
+
+This plugin provides a comprehensive solution for both client-side and server-side MCP communication within an MSA application. The specific `action` strings and `payload` structures will depend on the MCP server's implementation and the defined protocol.

--- a/packages/plugin-mcp/jest.config.js
+++ b/packages/plugin-mcp/jest.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+  displayName: 'plugin-mcp',
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/test/**/*.test.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.json' // This should point to packages/plugin-mcp/tsconfig.json
+    }
+  },
+  moduleNameMapper: {
+    // If you use path aliases in tsconfig.json that Jest needs to understand
+    // e.g., "^@core/(.*)$": "<rootDir>/../core/src/$1"
+    // For this plugin, we need to ensure it can find @arifwidianto/msa-core
+    '^@arifwidianto/msa-core$': '<rootDir>/../core/src/index.ts'
+  }
+};

--- a/packages/plugin-mcp/jest.config.js
+++ b/packages/plugin-mcp/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
   testMatch: ['<rootDir>/test/**/*.test.ts'],
   globals: {
     'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.json' // This should point to packages/plugin-mcp/tsconfig.json
+      tsconfig: '<rootDir>/tsconfig.json'
     }
   },
   moduleNameMapper: {

--- a/packages/plugin-mcp/package.json
+++ b/packages/plugin-mcp/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@arifwidianto/msa-plugin-mcp",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json"
+  },
+  "dependencies": {
+    "@arifwidianto/msa-core": "0.1.0",
+    "ws": "^8.17.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5",
+    "@types/ws": "^8.5.10"
+  },
+  "peerDependencies": {
+    "@arifwidianto/msa-core": "0.1.0"
+  }
+}

--- a/packages/plugin-mcp/package.json
+++ b/packages/plugin-mcp/package.json
@@ -4,7 +4,14 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc -p tsconfig.build.json"
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rimraf dist",
+    "dev": "tsc -p tsconfig.build.json --watch",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage",
+    "lint": "eslint src/**/*.ts",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@arifwidianto/msa-core": "0.1.0",
@@ -12,7 +19,15 @@
   },
   "devDependencies": {
     "typescript": "^5.4.5",
-    "@types/ws": "^8.5.10"
+    "@types/ws": "^8.5.10",
+    "rimraf": "^5.0.5",
+    "jest": "^29.7.0",
+    "@types/jest": "^29.5.12",
+    "eslint": "^8.52.0",
+    "@typescript-eslint/eslint-plugin": "^6.9.1",
+    "@typescript-eslint/parser": "^6.9.1",
+    "ts-jest": "^29.1.2",
+    "mock-socket": "^9.3.1"
   },
   "peerDependencies": {
     "@arifwidianto/msa-core": "0.1.0"

--- a/packages/plugin-mcp/src/MCPClient.ts
+++ b/packages/plugin-mcp/src/MCPClient.ts
@@ -1,0 +1,174 @@
+import WebSocket from 'ws';
+import { MCPRequest, MCPResponse, MCPMessage, MCPContext } from './mcp-types';
+import { Logger } from '@arifwidianto/msa-core'; // Assuming Logger is available and configured
+
+export class MCPClient {
+  private ws: WebSocket | null = null;
+  private serverUrl: string;
+  private pendingRequests: Map<string, { resolve: (response: MCPResponse) => void, reject: (error: Error) => void }> = new Map();
+  private onMessageHandler?: (message: MCPMessage) => void;
+  private connectionPromise: Promise<void> | null = null;
+  private connectionResolve: (() => void) | null = null;
+  private connectionReject: ((error: Error) => void) | null = null;
+  private autoReconnect: boolean = true; // Or make this configurable
+  private reconnectAttempts: number = 0;
+  private maxReconnectAttempts: number = 5; // Example
+  private reconnectInterval: number = 5000; // 5 seconds, example
+
+  constructor(serverUrl: string, autoReconnect: boolean = true, maxReconnectAttempts: number = 5, reconnectInterval: number = 5000) {
+    this.serverUrl = serverUrl;
+    this.autoReconnect = autoReconnect;
+    this.maxReconnectAttempts = maxReconnectAttempts;
+    this.reconnectInterval = reconnectInterval;
+    Logger.info(`MCPClient initialized for server URL: ${serverUrl}`);
+  }
+
+  public connect(): Promise<void> {
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+      return Promise.resolve();
+    }
+
+    // If a connection attempt is already in progress, return that promise
+    if (this.connectionPromise) {
+      return this.connectionPromise;
+    }
+
+    this.connectionPromise = new Promise((resolve, reject) => {
+      this.connectionResolve = resolve;
+      this.connectionReject = reject;
+
+      Logger.info(`MCPClient: Connecting to ${this.serverUrl}...`);
+      this.ws = new WebSocket(this.serverUrl);
+
+      this.ws.on('open', () => {
+        Logger.info(`MCPClient: Successfully connected to ${this.serverUrl}.`);
+        this.reconnectAttempts = 0; // Reset on successful connection
+        this.connectionResolve?.();
+        this.connectionPromise = null; // Clear promise for next connect attempt
+      });
+
+      this.ws.on('message', (data) => this.handleMessage(data));
+
+      this.ws.on('error', (err) => {
+        Logger.error(`MCPClient: WebSocket error: ${err.message}`);
+        this.connectionReject?.(err);
+        this.connectionPromise = null;
+        // Error event is often followed by 'close'. Reconnection logic is in 'close'.
+      });
+
+      this.ws.on('close', (code, reason) => {
+        const reasonStr = reason ? reason.toString() : 'No reason given';
+        Logger.info(`MCPClient: WebSocket connection closed. Code: ${code}, Reason: ${reasonStr}`);
+        this.ws = null; // Clear WebSocket instance
+
+        // Reject pending requests on close
+        this.pendingRequests.forEach((handler, requestId) => {
+          handler.reject(new Error(`MCPClient: Connection closed. Request ${requestId} failed.`));
+        });
+        this.pendingRequests.clear();
+        
+        if (this.autoReconnect && this.reconnectAttempts < this.maxReconnectAttempts) {
+          this.reconnectAttempts++;
+          Logger.info(`MCPClient: Attempting to reconnect in ${this.reconnectInterval / 1000}s... (Attempt ${this.reconnectAttempts}/${this.maxReconnectAttempts})`);
+          setTimeout(() => {
+            this.connect().catch(reconnectError => {
+                Logger.error(`MCPClient: Reconnect attempt ${this.reconnectAttempts} failed: ${reconnectError.message}`);
+            });
+          }, this.reconnectInterval);
+        } else if (this.autoReconnect) {
+            Logger.error(`MCPClient: Max reconnect attempts (${this.maxReconnectAttempts}) reached. Will not reconnect further.`);
+        }
+        // If connection was never established, the initial promise should be rejected
+        if (this.connectionReject && !this.connectionPromise) { // Check if connectionPromise is null to ensure it's not the active one
+            this.connectionReject(new Error(`MCPClient: Connection closed. Code: ${code}, Reason: ${reasonStr}`));
+        }
+      });
+    });
+    return this.connectionPromise;
+  }
+
+  private handleMessage(data: WebSocket.Data): void {
+    try {
+      const message = JSON.parse(data.toString()) as MCPMessage;
+      Logger.debug(`MCPClient: Received message: ${JSON.stringify(message)}`);
+
+      if (message.type === 'response' && this.pendingRequests.has(message.requestId)) {
+        const handler = this.pendingRequests.get(message.requestId);
+        if (message.status === 'success') {
+          handler?.resolve(message);
+        } else {
+          const errorMsg = message.error ? `${message.error.code}: ${message.error.message}` : 'Unknown error';
+          handler?.reject(new Error(`MCP Server Error: ${errorMsg}`));
+        }
+        this.pendingRequests.delete(message.requestId);
+      } else if (this.onMessageHandler) {
+        this.onMessageHandler(message); // For other messages or server pushes
+      } else {
+        Logger.warn(`MCPClient: Received unhandled message or no handler for response ID ${message.type === 'response' ? message.requestId : 'N/A'}`);
+      }
+    } catch (error) {
+      Logger.error(`MCPClient: Error handling incoming message: ${error instanceof Error ? error.message : String(error)}. Data: ${data.toString()}`);
+    }
+  }
+
+  public async sendRequest(action: string, payload: any, context?: MCPContext): Promise<MCPResponse> {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      Logger.warn(`MCPClient: Not connected. Attempting to connect before sending request for action: ${action}`);
+      // Attempt to connect if not connected. This might be too implicit for some use cases.
+      // Consider requiring explicit connect() call before sendRequest.
+      await this.connect(); // Wait for connection
+      if (!this.ws || this.ws.readyState !== WebSocket.OPEN) { // Check again after connect attempt
+          throw new Error('MCPClient: Connection failed. Cannot send request.');
+      }
+    }
+
+    const requestId = Date.now().toString(36) + Math.random().toString(36).substring(2); // More robust unique ID
+    const request: MCPRequest = {
+      messageId: requestId,
+      protocolVersion: '1.0',
+      timestamp: new Date().toISOString(),
+      type: 'request',
+      action,
+      payload,
+      context,
+    };
+
+    return new Promise((resolve, reject) => {
+      this.pendingRequests.set(requestId, { resolve, reject });
+      Logger.debug(`MCPClient: Sending request: ${JSON.stringify(request)}`);
+      this.ws!.send(JSON.stringify(request), (err) => {
+        if (err) {
+          Logger.error(`MCPClient: Error sending request ${requestId}: ${err.message}`);
+          this.pendingRequests.delete(requestId);
+          reject(err);
+        }
+      });
+      // Optional: Implement a timeout for requests
+      setTimeout(() => {
+        if (this.pendingRequests.has(requestId)) {
+          Logger.warn(`MCPClient: Request ${requestId} (action: ${action}) timed out.`);
+          this.pendingRequests.get(requestId)?.reject(new Error(`Request ${requestId} timed out`));
+          this.pendingRequests.delete(requestId);
+        }
+      }, 30000); // 30s timeout, make configurable
+    });
+  }
+  
+  public setOnMessageHandler(handler: (message: MCPMessage) => void): void {
+    this.onMessageHandler = handler;
+  }
+
+  public close(): void {
+    this.autoReconnect = false; // Prevent reconnection on manual close
+    if (this.ws) {
+      Logger.info(`MCPClient: Manually closing connection to ${this.serverUrl}.`);
+      this.ws.close();
+    } else {
+      Logger.info(`MCPClient: No active connection to close for ${this.serverUrl}.`);
+    }
+  }
+
+  public getReadyState(): number {
+    return this.ws ? this.ws.readyState : WebSocket.CLOSED;
+  }
+}

--- a/packages/plugin-mcp/src/MCPPlugin.ts
+++ b/packages/plugin-mcp/src/MCPPlugin.ts
@@ -1,0 +1,165 @@
+import { IPlugin, Logger, ITransport } from '@arifwidianto/msa-core';
+import { MCPClient } from './MCPClient';
+import { MCPPluginConfig } from './MCPPluginConfig';
+import { MCPServer, MCPRequestHandler } from './MCPServer'; // Import MCPServer
+
+// Helper type for core access if it were to be formalized
+// export interface CorePluginAccess {
+//   getService: () => any; // Replace 'any' with actual Service type
+//   getLogger: (context: string) => Logger;
+//   getPlugin: <T extends IPlugin>(pluginName: string) => T | undefined;
+// }
+
+
+export class MCPPlugin implements IPlugin {
+  public readonly name = 'msa-plugin-mcp';
+  public readonly version = '0.1.0';
+  public readonly dependencies: string[] = [];
+
+  private client: MCPClient | null = null;
+  private serverInstance: MCPServer | null = null;
+  private config: MCPPluginConfig | null = null;
+  // private logger: Logger; // Assume Logger is directly usable or passed via a CorePluginAccess object
+
+  // If core framework passes core utilities:
+  // constructor(private coreAccess?: CorePluginAccess) {
+  //   this.logger = coreAccess ? coreAccess.getLogger(this.name) : Logger; // Fallback to global Logger
+  // }
+  // For now, using imported Logger directly as per previous plugins.
+
+  public async initialize(
+    config: MCPPluginConfig,
+    transportForServer?: ITransport // This would be supplied by the service orchestrator
+  ): Promise<void> {
+    this.config = config;
+    // this.logger = this.coreAccess?.getLogger(this.name) || Logger; // Example if coreAccess was real
+
+    Logger.info(`${this.name}: Initializing...`);
+
+    // Initialize Client
+    if (config.client?.serverUrl) {
+      Logger.info(`${this.name}: Client mode configured with server URL: ${config.client.serverUrl}`);
+      this.client = new MCPClient(
+        config.client.serverUrl,
+        config.client.autoReconnectClient, // Now correctly named as per updated MCPPluginConfig
+        config.client.maxReconnectAttemptsClient,
+        config.client.reconnectIntervalClient
+      );
+    } else {
+      Logger.info(`${this.name}: Client mode not configured or serverUrl missing.`);
+    }
+
+    // Initialize Server
+    if (config.server?.enabled) {
+      Logger.info(`${this.name}: Server mode enabled.`);
+      if (transportForServer) {
+        this.serverInstance = new MCPServer(transportForServer, Logger); // Pass the Logger
+        Logger.info(`${this.name}: MCPServer instance created and attached to transport.`);
+      } else {
+        const errorMsg = `${this.name}: Server mode enabled, but no transport plugin instance was provided to initialize. MCPServer will not function.`;
+        Logger.error(errorMsg);
+        // Depending on strictness, could throw new Error(errorMsg);
+        // This setup assumes the orchestrating service handles providing the transport.
+        // If a transportPluginName was in config.server, the orchestrator would use that to fetch and pass it.
+      }
+    } else {
+      Logger.info(`${this.name}: Server mode not enabled.`);
+    }
+    Logger.info(`${this.name}: Initialization complete.`);
+  }
+
+  public async start(): Promise<void> {
+    Logger.info(`${this.name}: Starting...`);
+    if (this.client) {
+      try {
+        Logger.info(`${this.name}: Connecting MCPClient...`);
+        await this.client.connect();
+        Logger.info(`${this.name}: MCPClient connected successfully.`);
+      } catch (error) {
+        Logger.error(`${this.name}: Failed to connect MCPClient during start: ${error instanceof Error ? error.message : String(error)}`);
+        // Decide if this should prevent service start or just log
+      }
+    }
+    // MCPServer component is passive; it's "started" when its transport is started.
+    // No specific start action for serverInstance here as transport lifecycle is external.
+    if (this.serverInstance) {
+        Logger.info(`${this.name}: MCPServer is active (relies on its transport plugin's lifecycle).`);
+    }
+    Logger.info(`${this.name}: Start routine complete.`);
+  }
+
+  public async stop(): Promise<void> {
+    Logger.info(`${this.name}: Stopping...`);
+    if (this.client) {
+      Logger.info(`${this.name}: Closing MCPClient connection...`);
+      this.client.close();
+      Logger.info(`${this.name}: MCPClient connection closed.`);
+    }
+    // MCPServer component is passive; its transport is stopped by its own plugin's lifecycle.
+    if (this.serverInstance) {
+        Logger.info(`${this.name}: MCPServer will stop receiving messages when its transport stops.`);
+    }
+    Logger.info(`${this.name}: Stop routine complete.`);
+  }
+
+  public async cleanup(): Promise<void> {
+    Logger.info(`${this.name}: Cleaning up resources...`);
+    if (this.client) {
+      this.client.close(); // Ensure client connection is closed
+      this.client = null;
+    }
+    if (this.serverInstance) {
+      // MCPServer might have resources to clean up if it managed more than just handlers
+      // For now, it mainly holds references; nullifying should be sufficient.
+      // If MCPServer had, e.g., its own timers or persistent stores, they'd be cleaned here.
+      Logger.info(`${this.name}: Cleaning up MCPServer instance.`);
+      this.serverInstance = null;
+    }
+    this.config = null;
+    Logger.info(`${this.name}: Cleanup complete.`);
+  }
+
+  /**
+   * Provides access to the underlying MCPClient instance.
+   * @returns The MCPClient instance.
+   * @throws Error if the client part of the plugin has not been configured or initialized.
+   */
+  public getClient(): MCPClient {
+    if (!this.client) {
+      const errorMsg = `${this.name}: MCPClient is not available. Client mode may not be configured or plugin not initialized.`;
+      Logger.warn(errorMsg);
+      throw new Error(errorMsg);
+    }
+    return this.client;
+  }
+
+  /**
+   * Registers an action handler for the MCP Server.
+   * @param action The action string to register.
+   * @param handler The handler function for the action.
+   * @throws Error if the server part of the plugin is not initialized or enabled.
+   */
+  public registerServerAction(action: string, handler: MCPRequestHandler): void {
+    if (!this.serverInstance) {
+      const errorMsg = `${this.name}: MCPServer is not initialized or enabled. Cannot register action.`;
+      Logger.warn(errorMsg);
+      throw new Error(errorMsg);
+    }
+    this.serverInstance.registerAction(action, handler);
+  }
+
+  /**
+   * Provides access to the underlying MCPServer instance.
+   * Useful for advanced configuration or direct interaction not exposed via MCPPlugin.
+   * @returns The MCPServer instance.
+   * @throws Error if the server part of the plugin has not been configured or initialized.
+   */
+  public getServer(): MCPServer {
+    if (!this.serverInstance) {
+      const errorMsg = `${this.name}: MCPServer is not available. Server mode may not be configured or plugin not initialized.`;
+      Logger.warn(errorMsg);
+      throw new Error(errorMsg);
+    }
+    return this.serverInstance;
+  }
+}

--- a/packages/plugin-mcp/src/MCPPluginConfig.ts
+++ b/packages/plugin-mcp/src/MCPPluginConfig.ts
@@ -1,0 +1,19 @@
+import { PluginConfig } from '@arifwidianto/msa-core';
+
+export interface MCPServerConfig {
+  enabled: boolean; // To enable server mode
+  port?: number; // If using a dedicated port for MCP server (less relevant if using transport plugin)
+  host?: string; // If using a dedicated port
+  path?: string; // If WebSocket server is shared, e.g., /mcp (more relevant for WebSocket transport)
+  transportPluginName?: string; // Name of the transport plugin to use (e.g., 'msa-plugin-websocket')
+}
+
+export interface MCPPluginConfig extends PluginConfig {
+  client?: { // Existing client config
+    serverUrl: string;
+    autoReconnectClient?: boolean; // Optional: defaults to true in MCPClient
+    maxReconnectAttemptsClient?: number; // Optional: defaults to 5 in MCPClient
+    reconnectIntervalClient?: number;   // Optional: defaults to 5000ms in MCPClient
+  };
+  server?: MCPServerConfig;
+}

--- a/packages/plugin-mcp/src/MCPServer.ts
+++ b/packages/plugin-mcp/src/MCPServer.ts
@@ -1,5 +1,5 @@
 import { MCPRequest, MCPResponse, MCPContext, MCPMessage } from './mcp-types';
-import { ITransport, Logger as MsaLogger } from '@arifwidianto/msa-core'; // Renamed to avoid conflict
+import { ITransport, Logger } from '@arifwidianto/msa-core'; // Added LoggerType import
 
 // Define a simpler Logger interface for MCPServer if full MsaLogger is not directly available
 // or assume MsaLogger can be passed in. For this implementation, we'll use MsaLogger type.
@@ -10,17 +10,18 @@ export type MCPRequestHandler = (request: MCPRequest, context: MCPContext) => Pr
 export class MCPServer {
   private transport: ITransport;
   private requestHandlers: Map<string, MCPRequestHandler> = new Map();
-  private logger: MsaLogger; // Use the MsaLogger type from msa-core
+  private logger: typeof Logger; // Use the LoggerType from msa-core
 
   private readonly offMessage?: () => void;
 
-  constructor(transportPlugin: ITransport, logger: MsaLogger) {
+  constructor(transportPlugin: ITransport, logger: typeof Logger) {
     this.transport = transportPlugin;
     this.logger = logger;
 
     // The transport plugin should already be configured and started by the core Service.
     // The onMessage handler of the transport plugin is the entry point for MCPServer.
-    this.offMessage = this.transport.onMessage(this.handleRawMessage.bind(this));
+    const offResult = this.transport.onMessage(this.handleRawMessage.bind(this));
+    this.offMessage = typeof offResult === 'function' ? offResult : undefined;
     this.logger.info('MCPServer initialized. Listening for messages on the provided transport.');
   }
 
@@ -38,13 +39,13 @@ export class MCPServer {
 
   private async handleRawMessage(rawMessage: any, senderId?: string): Promise<void> {
     // senderId might be provided by ITransport if it supports multiple clients (e.g., individual WebSockets)
-    this.logger.debug({ rawMessage, senderId }, 'MCPServer: Received raw message from transport.');
+    this.logger.debug('MCPServer: Received raw message from transport.', { rawMessage, senderId });
     try {
       const message = typeof rawMessage === 'string' ? JSON.parse(rawMessage) : rawMessage;
 
       if (message.type === 'request') {
         const request = message as MCPRequest;
-        this.logger.info({ requestId: request.messageId, action: request.action, senderId }, 'MCPServer: MCP Request received');
+        this.logger.info('MCPServer: MCP Request received', { requestId: request.messageId, action: request.action, senderId });
         
         const handler = this.requestHandlers.get(request.action);
         let responsePayload: Partial<MCPResponse>;
@@ -53,14 +54,14 @@ export class MCPServer {
           try {
             responsePayload = await handler(request, request.context || {});
           } catch (handlerError) {
-            this.logger.error({ requestId: request.messageId, action: request.action, error: handlerError }, 'MCPServer: Error in request handler');
+            this.logger.error('MCPServer: Error in request handler', { requestId: request.messageId, action: request.action, error: handlerError });
             responsePayload = {
               status: 'error',
               error: { code: 'HANDLER_EXCEPTION', message: handlerError instanceof Error ? handlerError.message : String(handlerError) }
             };
           }
         } else {
-          this.logger.warn({ requestId: request.messageId, action: request.action }, 'MCPServer: No handler found for action');
+          this.logger.warn('MCPServer: No handler found for action', { requestId: request.messageId, action: request.action });
           responsePayload = {
             status: 'error',
             error: { code: 'NO_HANDLER', message: `No handler registered for action: ${request.action}` }
@@ -83,18 +84,18 @@ export class MCPServer {
         // Otherwise, assume transport.send handles broadcasting or appropriate routing.
         if (senderId && isTargetedTransport(this.transport)) {
             // Use the type-safe sendTo method
-            this.logger.debug({ response, senderId }, 'MCPServer: Sending response to specific sender.');
+            this.logger.debug('MCPServer: Sending response to specific sender.', { response, senderId });
             await this.transport.sendTo(senderId, JSON.stringify(response));
         } else {
-            this.logger.debug({ response }, 'MCPServer: Sending/broadcasting response via transport.');
+            this.logger.debug('MCPServer: Sending/broadcasting response via transport.', { response });
             await this.transport.send(JSON.stringify(response));
         }
 
       } else {
-        this.logger.warn({ message }, 'MCPServer: Received non-request message type, ignoring.');
+        this.logger.warn('MCPServer: Received non-request message type, ignoring.', { message });
       }
     } catch (error) {
-      this.logger.error({ error, rawMessage }, 'MCPServer: Error processing raw message.');
+      this.logger.error('MCPServer: Error processing raw message.', { error, rawMessage });
       // Consider sending a generic error response if the request ID can be parsed and it was a request.
       // This part is tricky if the message itself is malformed.
       // For now, just logging. If `message` was parsed and `requestId` is available:

--- a/packages/plugin-mcp/src/MCPServer.ts
+++ b/packages/plugin-mcp/src/MCPServer.ts
@@ -1,0 +1,111 @@
+import { MCPRequest, MCPResponse, MCPContext, MCPMessage } from './mcp-types';
+import { ITransport, Logger as MsaLogger } from '@arifwidianto/msa-core'; // Renamed to avoid conflict
+
+// Define a simpler Logger interface for MCPServer if full MsaLogger is not directly available
+// or assume MsaLogger can be passed in. For this implementation, we'll use MsaLogger type.
+// If MsaLogger is not directly passed, a wrapper or a simpler logger might be used.
+
+export type MCPRequestHandler = (request: MCPRequest, context: MCPContext) => Promise<Partial<MCPResponse>>;
+
+export class MCPServer {
+  private transport: ITransport;
+  private requestHandlers: Map<string, MCPRequestHandler> = new Map();
+  private logger: MsaLogger; // Use the MsaLogger type from msa-core
+
+  constructor(transportPlugin: ITransport, logger: MsaLogger) {
+    this.transport = transportPlugin;
+    this.logger = logger;
+
+    // The transport plugin should already be configured and started by the core Service.
+    // The onMessage handler of the transport plugin is the entry point for MCPServer.
+    this.transport.onMessage(this.handleRawMessage.bind(this));
+    this.logger.info('MCPServer initialized. Listening for messages on the provided transport.');
+  }
+
+  private async handleRawMessage(rawMessage: any, senderId?: string): Promise<void> {
+    // senderId might be provided by ITransport if it supports multiple clients (e.g., individual WebSockets)
+    this.logger.debug({ rawMessage, senderId }, 'MCPServer: Received raw message from transport.');
+    try {
+      const message = typeof rawMessage === 'string' ? JSON.parse(rawMessage) : rawMessage;
+
+      if (message.type === 'request') {
+        const request = message as MCPRequest;
+        this.logger.info({ requestId: request.messageId, action: request.action, senderId }, 'MCPServer: MCP Request received');
+        
+        const handler = this.requestHandlers.get(request.action);
+        let responsePayload: Partial<MCPResponse>;
+
+        if (handler) {
+          try {
+            responsePayload = await handler(request, request.context || {});
+          } catch (handlerError) {
+            this.logger.error({ requestId: request.messageId, action: request.action, error: handlerError }, 'MCPServer: Error in request handler');
+            responsePayload = {
+              status: 'error',
+              error: { code: 'HANDLER_EXCEPTION', message: handlerError instanceof Error ? handlerError.message : String(handlerError) }
+            };
+          }
+        } else {
+          this.logger.warn({ requestId: request.messageId, action: request.action }, 'MCPServer: No handler found for action');
+          responsePayload = {
+            status: 'error',
+            error: { code: 'NO_HANDLER', message: `No handler registered for action: ${request.action}` }
+          };
+        }
+        
+        const response: MCPResponse = {
+          messageId: `res-${Date.now().toString(36)}-${Math.random().toString(36).substring(2)}`, // Unique response ID
+          protocolVersion: request.protocolVersion,
+          timestamp: new Date().toISOString(),
+          type: 'response',
+          requestId: request.messageId,
+          status: responsePayload.status || 'success', // Default to success if handler doesn't specify
+          payload: responsePayload.payload,
+          error: responsePayload.error,
+          context: responsePayload.context // Handler can update context
+        };
+        
+        // Send the response. If senderId is available and transport supports it, use it.
+        // Otherwise, assume transport.send handles broadcasting or appropriate routing.
+        if (senderId && typeof (this.transport as any).sendTo === 'function') {
+            // This is a hypothetical sendTo method, actual ITransport might differ
+            this.logger.debug({ response, senderId }, 'MCPServer: Sending response to specific sender.');
+            await (this.transport as any).sendTo(senderId, JSON.stringify(response));
+        } else {
+            this.logger.debug({ response }, 'MCPServer: Sending/broadcasting response via transport.');
+            await this.transport.send(JSON.stringify(response));
+        }
+
+      } else {
+        this.logger.warn({ message }, 'MCPServer: Received non-request message type, ignoring.');
+      }
+    } catch (error) {
+      this.logger.error({ error, rawMessage }, 'MCPServer: Error processing raw message.');
+      // Consider sending a generic error response if the request ID can be parsed and it was a request.
+      // This part is tricky if the message itself is malformed.
+      // For now, just logging. If `message` was parsed and `requestId` is available:
+      // const parsedMessage = JSON.parse(rawMessage.toString()) as MCPMessage;
+      // if (parsedMessage && parsedMessage.type === 'request' && parsedMessage.messageId) {
+      //   const errorResponse: MCPResponse = { ... };
+      //   await this.transport.send(JSON.stringify(errorResponse));
+      // }
+    }
+  }
+
+  public registerAction(action: string, handler: MCPRequestHandler): void {
+    if (this.requestHandlers.has(action)) {
+      this.logger.warn(`MCPServer: Overwriting handler for action: ${action}`);
+    }
+    this.requestHandlers.set(action, handler);
+    this.logger.info(`MCPServer: Registered MCP action handler for: ${action}`);
+  }
+
+  // Optional: Method to unregister an action
+  public unregisterAction(action: string): void {
+    if (this.requestHandlers.delete(action)) {
+      this.logger.info(`MCPServer: Unregistered MCP action handler for: ${action}`);
+    } else {
+      this.logger.warn(`MCPServer: No action handler found to unregister for: ${action}`);
+    }
+  }
+}

--- a/packages/plugin-mcp/src/index.ts
+++ b/packages/plugin-mcp/src/index.ts
@@ -1,0 +1,5 @@
+export { MCPPlugin } from './MCPPlugin';
+export { MCPPluginConfig, MCPServerConfig } from './MCPPluginConfig'; // Ensure MCPServerConfig is exported
+export { MCPClient } from './MCPClient';
+export { MCPServer, MCPRequestHandler } from './MCPServer'; // Export MCPServer and MCPRequestHandler
+export * from './mcp-types'; // Export all types from mcp-types.ts

--- a/packages/plugin-mcp/src/mcp-types.ts
+++ b/packages/plugin-mcp/src/mcp-types.ts
@@ -1,0 +1,28 @@
+export interface MCPMessageBase {
+  messageId: string;
+  protocolVersion: string; // e.g., "1.0"
+  timestamp: string; // ISO 8601
+}
+
+export interface MCPContext {
+  sessionId?: string;
+  [key: string]: any; // For arbitrary context data
+}
+
+export interface MCPRequest extends MCPMessageBase {
+  type: 'request';
+  action: string; // e.g., "generate_text", "get_capabilities"
+  payload: any;
+  context?: MCPContext;
+}
+
+export interface MCPResponse extends MCPMessageBase {
+  type: 'response';
+  requestId: string; // Corresponds to MCPRequest.messageId
+  status: 'success' | 'error';
+  payload?: any;
+  error?: { code: string; message: string; };
+  context?: MCPContext; // Updated context
+}
+
+export type MCPMessage = MCPRequest | MCPResponse;

--- a/packages/plugin-mcp/test/MCPClient.test.ts
+++ b/packages/plugin-mcp/test/MCPClient.test.ts
@@ -14,7 +14,12 @@ jest.mock('@arifwidianto/msa-core', () => ({
 }));
 
 // Mock 'ws' (WebSocket)
-const mockWebSocketInstance = {
+const mockWebSocketInstance: {
+  on: jest.Mock;
+  send: jest.Mock;
+  close: jest.Mock;
+  readyState: number;
+} = {
   on: jest.fn(),
   send: jest.fn(),
   close: jest.fn(),
@@ -224,7 +229,7 @@ describe('MCPClient', () => {
     it('should throw error if not connected', async () => {
       mockWebSocketInstance.readyState = WebSocket.CLOSED; // Simulate not connected
       // MCPClient's sendRequest now tries to connect, so we need to ensure that connect also fails for this test.
-      (WebSocket as jest.Mock).mockImplementationOnce(() => {
+      (WebSocket as unknown as jest.Mock).mockImplementationOnce(() => {
         const ws = { ...mockWebSocketInstance, readyState: WebSocket.CONNECTING };
         setTimeout(() => ws.on.mock.calls.find(c => c[0] === 'error')[1](new Error("Forced connect fail")), 50);
         return ws;
@@ -297,7 +302,7 @@ describe('MCPClient', () => {
       client = new MCPClient(serverUrl, true, 2, 1000); // Max 2 attempts, 1s interval
       let openCallback: any, errorCallback: any, closeCallback: any;
 
-      (WebSocket as jest.Mock).mockImplementation(() => {
+      (WebSocket as unknown as jest.Mock).mockImplementation(() => {
         // Ensure each new WebSocket mock instance gets its own event setup
         const newWsMock = { ...mockWebSocketInstance, on: jest.fn(), close: jest.fn(), readyState: WebSocket.CONNECTING };
         (newWsMock.on as jest.Mock).mockImplementation((event, callback) => {

--- a/packages/plugin-mcp/test/MCPClient.test.ts
+++ b/packages/plugin-mcp/test/MCPClient.test.ts
@@ -1,0 +1,332 @@
+import { MCPClient } from '../src/MCPClient';
+import { MCPRequest, MCPResponse, MCPMessage, MCPContext } from '../src/mcp-types';
+import { Logger } from '@arifwidianto/msa-core';
+import WebSocket from 'ws';
+
+// Mock Logger from @arifwidianto/msa-core
+jest.mock('@arifwidianto/msa-core', () => ({
+  Logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+// Mock 'ws' (WebSocket)
+const mockWebSocketInstance = {
+  on: jest.fn(),
+  send: jest.fn(),
+  close: jest.fn(),
+  readyState: WebSocket.CLOSED, // Initial state
+};
+jest.mock('ws', () => jest.fn().mockImplementation(() => mockWebSocketInstance));
+
+describe('MCPClient', () => {
+  let client: MCPClient;
+  const serverUrl = 'ws://localhost:8080/mcp';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Reset WebSocket instance for each test to ensure clean event handlers
+    Object.assign(mockWebSocketInstance, {
+      on: jest.fn(),
+      send: jest.fn(),
+      close: jest.fn(),
+      readyState: WebSocket.CLOSED,
+    });
+    client = new MCPClient(serverUrl);
+  });
+
+  describe('Connection', () => {
+    it('should connect to the server and resolve promise on open', async () => {
+      (mockWebSocketInstance.on as jest.Mock).mockImplementation((event, callback) => {
+        if (event === 'open') {
+          mockWebSocketInstance.readyState = WebSocket.OPEN;
+          callback(); // Simulate 'open' event
+        }
+      });
+      await client.connect();
+      expect(WebSocket).toHaveBeenCalledWith(serverUrl);
+      expect(mockWebSocketInstance.on).toHaveBeenCalledWith('open', expect.any(Function));
+      expect(mockWebSocketInstance.on).toHaveBeenCalledWith('message', expect.any(Function));
+      expect(mockWebSocketInstance.on).toHaveBeenCalledWith('error', expect.any(Function));
+      expect(mockWebSocketInstance.on).toHaveBeenCalledWith('close', expect.any(Function));
+      expect(Logger.info).toHaveBeenCalledWith(`MCPClient: Successfully connected to ${serverUrl}.`);
+    });
+
+    it('should reject promise on connection error', async () => {
+      const error = new Error('Connection failed');
+      (mockWebSocketInstance.on as jest.Mock).mockImplementation((event, callback) => {
+        if (event === 'error') {
+          callback(error); // Simulate 'error' event
+        }
+      });
+      await expect(client.connect()).rejects.toThrow(error);
+      expect(Logger.error).toHaveBeenCalledWith(`MCPClient: WebSocket error: ${error.message}`);
+    });
+    
+    it('should handle close event and reject pending requests', (done) => {
+        const closeCode = 1006;
+        const closeReason = 'Abnormal closure';
+
+        (mockWebSocketInstance.on as jest.Mock).mockImplementation((event, callback) => {
+            if (event === 'open') {
+                mockWebSocketInstance.readyState = WebSocket.OPEN;
+                callback();
+            } else if (event === 'close') {
+                // Simulate close after a slight delay to allow a request to be "pending"
+                setTimeout(() => {
+                    mockWebSocketInstance.readyState = WebSocket.CLOSED;
+                    callback(closeCode, closeReason);
+
+                    // Assertions after close event has been processed
+                    expect(Logger.info).toHaveBeenCalledWith(expect.stringContaining(`MCPClient: WebSocket connection closed. Code: ${closeCode}, Reason: ${closeReason}`));
+                    done(); // Signal test completion
+                }, 50);
+            }
+        });
+
+        client.connect().then(() => {
+            // Send a request that will become pending
+            client.sendRequest('testAction', { data: 'test' }).catch(err => {
+                expect(err.message).toContain('MCPClient: Connection closed. Request');
+            });
+        });
+    });
+  });
+
+  describe('Message Handling', () => {
+    beforeEach(async () => {
+      // Simulate successful connection for these tests
+      (mockWebSocketInstance.on as jest.Mock).mockImplementation((event, callback) => {
+        if (event === 'open') {
+          mockWebSocketInstance.readyState = WebSocket.OPEN;
+          callback();
+        }
+      });
+      await client.connect();
+    });
+
+    it('should process incoming response and resolve pending request', (done) => {
+      const requestId = 'req123';
+      const responsePayload = { result: 'success' };
+      const response: MCPResponse = {
+        messageId: 'res456',
+        protocolVersion: '1.0',
+        timestamp: new Date().toISOString(),
+        type: 'response',
+        requestId,
+        status: 'success',
+        payload: responsePayload,
+      };
+
+      // Manually add to pendingRequests for test, as sendRequest is complex to fully mock here
+      // @ts-ignore - Accessing private member for test
+      client['pendingRequests'].set(requestId, { 
+        resolve: (res) => {
+          expect(res).toEqual(response);
+          done();
+        }, 
+        reject: jest.fn() 
+      });
+      
+      // Simulate receiving a message
+      const messageHandler = (mockWebSocketInstance.on as jest.Mock).mock.calls.find(call => call[0] === 'message')[1];
+      messageHandler(JSON.stringify(response));
+
+      expect(Logger.debug).toHaveBeenCalledWith(expect.stringContaining(JSON.stringify(response)));
+    });
+
+    it('should call onMessageHandler for non-response messages or unhandled responses', () => {
+      const customHandler = jest.fn();
+      client.setOnMessageHandler(customHandler);
+
+      const serverPushMessage: MCPRequest = { // Example of a server-initiated request (if protocol supports)
+        messageId: 'serverPush789',
+        protocolVersion: '1.0',
+        timestamp: new Date().toISOString(),
+        type: 'request',
+        action: 'notify_update',
+        payload: { info: 'System will restart' },
+      };
+      
+      const messageHandler = (mockWebSocketInstance.on as jest.Mock).mock.calls.find(call => call[0] === 'message')[1];
+      messageHandler(JSON.stringify(serverPushMessage));
+      
+      expect(customHandler).toHaveBeenCalledWith(serverPushMessage);
+    });
+    
+    it('should handle JSON parsing errors gracefully', () => {
+        const invalidJson = "{ not: json";
+        const messageHandler = (mockWebSocketInstance.on as jest.Mock).mock.calls.find(call => call[0] === 'message')[1];
+        messageHandler(invalidJson);
+        expect(Logger.error).toHaveBeenCalledWith(expect.stringContaining(`Error handling incoming message: Unexpected token`));
+    });
+  });
+
+  describe('sendRequest', () => {
+    beforeEach(async () => {
+      (mockWebSocketInstance.on as jest.Mock).mockImplementation((event, callback) => {
+        if (event === 'open') {
+          mockWebSocketInstance.readyState = WebSocket.OPEN;
+          callback();
+        }
+      });
+      await client.connect();
+    });
+
+    it('should send a request and store it in pendingRequests', async () => {
+      const action = 'testAction';
+      const payload = { data: 'test' };
+      (mockWebSocketInstance.send as jest.Mock).mockImplementation((data, cb) => cb()); // Simulate successful send
+
+      const responsePromise = client.sendRequest(action, payload);
+
+      // Check that send was called with a valid MCPRequest
+      expect(mockWebSocketInstance.send).toHaveBeenCalledWith(
+        expect.stringContaining(`"type":"request","action":"${action}"`),
+        expect.any(Function)
+      );
+      
+      // Check that a request ID was generated and is in pendingRequests
+      const sentData = JSON.parse((mockWebSocketInstance.send as jest.Mock).mock.calls[0][0]);
+      // @ts-ignore
+      expect(client['pendingRequests'].has(sentData.messageId)).toBe(true);
+
+      // Simulate receiving a response for this request to resolve the promise
+      const mockResponse: MCPResponse = {
+        messageId: 'responseId',
+        protocolVersion: '1.0',
+        timestamp: new Date().toISOString(),
+        type: 'response',
+        requestId: sentData.messageId,
+        status: 'success',
+        payload: { result: 'ok' }
+      };
+      const messageHandler = (mockWebSocketInstance.on as jest.Mock).mock.calls.find(call => call[0] === 'message')[1];
+      messageHandler(JSON.stringify(mockResponse)); // Simulate server response
+
+      await expect(responsePromise).resolves.toEqual(mockResponse);
+    });
+
+    it('should reject if WebSocket send fails', async () => {
+      const sendError = new Error('Send failed');
+      (mockWebSocketInstance.send as jest.Mock).mockImplementation((data, cb) => cb(sendError));
+      
+      await expect(client.sendRequest('failAction', {})).rejects.toThrow(sendError);
+    });
+
+    it('should throw error if not connected', async () => {
+      mockWebSocketInstance.readyState = WebSocket.CLOSED; // Simulate not connected
+      // MCPClient's sendRequest now tries to connect, so we need to ensure that connect also fails for this test.
+      (WebSocket as jest.Mock).mockImplementationOnce(() => {
+          const ws = { ...mockWebSocketInstance, readyState: WebSocket.CONNECTING };
+          setTimeout(() => ws.on.mock.calls.find(c => c[0] === 'error')[1](new Error("Forced connect fail")), 50);
+          return ws;
+      });
+      await expect(client.sendRequest('action', {})).rejects.toThrow('MCPClient: Connection failed. Cannot send request.');
+    });
+    
+    it('should handle request timeout', async () => {
+        jest.useFakeTimers();
+        const action = 'timeoutAction';
+        (mockWebSocketInstance.send as jest.Mock).mockImplementation((data, cb) => cb());
+
+        const responsePromise = client.sendRequest(action, {});
+        
+        // Fast-forward time until 30s timeout occurs
+        jest.advanceTimersByTime(30000);
+
+        await expect(responsePromise).rejects.toThrow(expect.stringContaining('timed out'));
+        expect(Logger.warn).toHaveBeenCalledWith(expect.stringContaining(`Request ${expect.any(String)} (action: ${action}) timed out.`));
+        jest.useRealTimers();
+    });
+  });
+
+  describe('Close', () => {
+    it('should close the WebSocket connection', () => {
+      client.close();
+      expect(mockWebSocketInstance.close).toHaveBeenCalled();
+      expect(Logger.info).toHaveBeenCalledWith(expect.stringContaining('Manually closing connection'));
+    });
+  });
+  
+  describe('Auto-Reconnection', () => {
+    jest.useFakeTimers();
+
+    afterEach(() => {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+    });
+
+    it('should attempt to reconnect on close if autoReconnect is true', async () => {
+        let openCallback: any, errorCallback: any, closeCallback: any;
+        (mockWebSocketInstance.on as jest.Mock).mockImplementation((event, callback) => {
+            if (event === 'open') openCallback = callback;
+            if (event === 'error') errorCallback = callback;
+            if (event === 'close') closeCallback = callback;
+        });
+
+        // Initial connection
+        const connectPromise = client.connect();
+        if (openCallback) openCallback(); // Simulate open
+        await connectPromise;
+
+        // Simulate unexpected close
+        if (closeCallback) closeCallback(1006, 'Network lost');
+        
+        expect(Logger.info).toHaveBeenCalledWith(expect.stringContaining('Attempting to reconnect'));
+
+        // Fast-forward to trigger reconnect attempt
+        jest.advanceTimersByTime(5000); // Default reconnectInterval
+
+        // Expect WebSocket to be called again for reconnection
+        // The first call was for the initial connect, so this should be the second call.
+        expect(WebSocket).toHaveBeenCalledTimes(2); 
+    });
+
+    it('should stop reconnecting after maxReconnectAttempts', async () => {
+        client = new MCPClient(serverUrl, true, 2, 1000); // Max 2 attempts, 1s interval
+        let openCallback: any, errorCallback: any, closeCallback: any;
+
+        (WebSocket as jest.Mock).mockImplementation(() => {
+            // Ensure each new WebSocket mock instance gets its own event setup
+            const newWsMock = { ...mockWebSocketInstance, on: jest.fn(), close: jest.fn(), readyState: WebSocket.CONNECTING };
+            (newWsMock.on as jest.Mock).mockImplementation((event, callback) => {
+                if (event === 'open') openCallback = callback;
+                if (event === 'error') errorCallback = callback; // For connect failures
+                if (event === 'close') closeCallback = callback;
+            });
+             // Simulate connection failure for reconnect attempts
+            setTimeout(() => {
+                if (errorCallback) errorCallback(new Error("Simulated connect error"));
+                if (closeCallback) closeCallback(1006); // Also trigger close
+            }, 50);
+            return newWsMock;
+        });
+        
+        // Initial connection attempt (which will fail as per mock above)
+        client.connect().catch(() => {}); // Catch initial error
+        
+        // Simulate first failure and trigger close
+        jest.advanceTimersByTime(100); 
+
+        // Reconnect attempt 1
+        jest.advanceTimersByTime(1000); // Interval
+        jest.advanceTimersByTime(100);  // Simulate failure of attempt 1
+
+        // Reconnect attempt 2
+        jest.advanceTimersByTime(1000); // Interval
+        jest.advanceTimersByTime(100);  // Simulate failure of attempt 2
+
+        // Should log max attempts reached
+        expect(Logger.error).toHaveBeenCalledWith(expect.stringContaining('Max reconnect attempts (2) reached.'));
+        
+        // Should not try to connect a 4th time (initial + 2 retries)
+        jest.advanceTimersByTime(1000); // Pass another interval
+        expect(WebSocket).toHaveBeenCalledTimes(3); // Initial (1) + Reconnect Attempt 1 (2) + Reconnect Attempt 2 (3)
+    });
+    jest.useRealTimers();
+  });
+});

--- a/packages/plugin-mcp/test/MCPClient.test.ts
+++ b/packages/plugin-mcp/test/MCPClient.test.ts
@@ -20,8 +20,12 @@ const mockWebSocketInstance = {
   close: jest.fn(),
   readyState: WebSocket.CLOSED, // Initial state
 };
-jest.mock('ws', () => jest.fn().mockImplementation(() => mockWebSocketInstance));
-
+const WS_MOCK = jest.fn().mockImplementation(() => mockWebSocketInstance);
+(WS_MOCK as any).CONNECTING = 0;
+(WS_MOCK as any).OPEN = 1;
+(WS_MOCK as any).CLOSING = 2;
+(WS_MOCK as any).CLOSED = 3;
+jest.mock('ws', () => WS_MOCK);
 describe('MCPClient', () => {
   let client: MCPClient;
   const serverUrl = 'ws://localhost:8080/mcp';
@@ -65,34 +69,34 @@ describe('MCPClient', () => {
       await expect(client.connect()).rejects.toThrow(error);
       expect(Logger.error).toHaveBeenCalledWith(`MCPClient: WebSocket error: ${error.message}`);
     });
-    
+
     it('should handle close event and reject pending requests', (done) => {
-        const closeCode = 1006;
-        const closeReason = 'Abnormal closure';
+      const closeCode = 1006;
+      const closeReason = 'Abnormal closure';
 
-        (mockWebSocketInstance.on as jest.Mock).mockImplementation((event, callback) => {
-            if (event === 'open') {
-                mockWebSocketInstance.readyState = WebSocket.OPEN;
-                callback();
-            } else if (event === 'close') {
-                // Simulate close after a slight delay to allow a request to be "pending"
-                setTimeout(() => {
-                    mockWebSocketInstance.readyState = WebSocket.CLOSED;
-                    callback(closeCode, closeReason);
+      (mockWebSocketInstance.on as jest.Mock).mockImplementation((event, callback) => {
+        if (event === 'open') {
+          mockWebSocketInstance.readyState = WebSocket.OPEN;
+          callback();
+        } else if (event === 'close') {
+          // Simulate close after a slight delay to allow a request to be "pending"
+          setTimeout(() => {
+            mockWebSocketInstance.readyState = WebSocket.CLOSED;
+            callback(closeCode, closeReason);
 
-                    // Assertions after close event has been processed
-                    expect(Logger.info).toHaveBeenCalledWith(expect.stringContaining(`MCPClient: WebSocket connection closed. Code: ${closeCode}, Reason: ${closeReason}`));
-                    done(); // Signal test completion
-                }, 50);
-            }
+            // Assertions after close event has been processed
+            expect(Logger.info).toHaveBeenCalledWith(expect.stringContaining(`MCPClient: WebSocket connection closed. Code: ${closeCode}, Reason: ${closeReason}`));
+            done(); // Signal test completion
+          }, 50);
+        }
+      });
+
+      client.connect().then(() => {
+        // Send a request that will become pending
+        client.sendRequest('testAction', { data: 'test' }).catch(err => {
+          expect(err.message).toContain('MCPClient: Connection closed. Request');
         });
-
-        client.connect().then(() => {
-            // Send a request that will become pending
-            client.sendRequest('testAction', { data: 'test' }).catch(err => {
-                expect(err.message).toContain('MCPClient: Connection closed. Request');
-            });
-        });
+      });
     });
   });
 
@@ -123,14 +127,14 @@ describe('MCPClient', () => {
 
       // Manually add to pendingRequests for test, as sendRequest is complex to fully mock here
       // @ts-ignore - Accessing private member for test
-      client['pendingRequests'].set(requestId, { 
+      client['pendingRequests'].set(requestId, {
         resolve: (res) => {
           expect(res).toEqual(response);
           done();
-        }, 
-        reject: jest.fn() 
+        },
+        reject: jest.fn()
       });
-      
+
       // Simulate receiving a message
       const messageHandler = (mockWebSocketInstance.on as jest.Mock).mock.calls.find(call => call[0] === 'message')[1];
       messageHandler(JSON.stringify(response));
@@ -150,18 +154,18 @@ describe('MCPClient', () => {
         action: 'notify_update',
         payload: { info: 'System will restart' },
       };
-      
+
       const messageHandler = (mockWebSocketInstance.on as jest.Mock).mock.calls.find(call => call[0] === 'message')[1];
       messageHandler(JSON.stringify(serverPushMessage));
-      
+
       expect(customHandler).toHaveBeenCalledWith(serverPushMessage);
     });
-    
+
     it('should handle JSON parsing errors gracefully', () => {
-        const invalidJson = "{ not: json";
-        const messageHandler = (mockWebSocketInstance.on as jest.Mock).mock.calls.find(call => call[0] === 'message')[1];
-        messageHandler(invalidJson);
-        expect(Logger.error).toHaveBeenCalledWith(expect.stringContaining(`Error handling incoming message: Unexpected token`));
+      const invalidJson = "{ not: json";
+      const messageHandler = (mockWebSocketInstance.on as jest.Mock).mock.calls.find(call => call[0] === 'message')[1];
+      messageHandler(invalidJson);
+      expect(Logger.error).toHaveBeenCalledWith(expect.stringContaining(`Error handling incoming message: Unexpected token`));
     });
   });
 
@@ -188,7 +192,7 @@ describe('MCPClient', () => {
         expect.stringContaining(`"type":"request","action":"${action}"`),
         expect.any(Function)
       );
-      
+
       // Check that a request ID was generated and is in pendingRequests
       const sentData = JSON.parse((mockWebSocketInstance.send as jest.Mock).mock.calls[0][0]);
       // @ts-ignore
@@ -213,7 +217,7 @@ describe('MCPClient', () => {
     it('should reject if WebSocket send fails', async () => {
       const sendError = new Error('Send failed');
       (mockWebSocketInstance.send as jest.Mock).mockImplementation((data, cb) => cb(sendError));
-      
+
       await expect(client.sendRequest('failAction', {})).rejects.toThrow(sendError);
     });
 
@@ -221,26 +225,26 @@ describe('MCPClient', () => {
       mockWebSocketInstance.readyState = WebSocket.CLOSED; // Simulate not connected
       // MCPClient's sendRequest now tries to connect, so we need to ensure that connect also fails for this test.
       (WebSocket as jest.Mock).mockImplementationOnce(() => {
-          const ws = { ...mockWebSocketInstance, readyState: WebSocket.CONNECTING };
-          setTimeout(() => ws.on.mock.calls.find(c => c[0] === 'error')[1](new Error("Forced connect fail")), 50);
-          return ws;
+        const ws = { ...mockWebSocketInstance, readyState: WebSocket.CONNECTING };
+        setTimeout(() => ws.on.mock.calls.find(c => c[0] === 'error')[1](new Error("Forced connect fail")), 50);
+        return ws;
       });
       await expect(client.sendRequest('action', {})).rejects.toThrow('MCPClient: Connection failed. Cannot send request.');
     });
-    
+
     it('should handle request timeout', async () => {
-        jest.useFakeTimers();
-        const action = 'timeoutAction';
-        (mockWebSocketInstance.send as jest.Mock).mockImplementation((data, cb) => cb());
+      jest.useFakeTimers();
+      const action = 'timeoutAction';
+      (mockWebSocketInstance.send as jest.Mock).mockImplementation((data, cb) => cb());
 
-        const responsePromise = client.sendRequest(action, {});
-        
-        // Fast-forward time until 30s timeout occurs
-        jest.advanceTimersByTime(30000);
+      const responsePromise = client.sendRequest(action, {});
 
-        await expect(responsePromise).rejects.toThrow(expect.stringContaining('timed out'));
-        expect(Logger.warn).toHaveBeenCalledWith(expect.stringContaining(`Request ${expect.any(String)} (action: ${action}) timed out.`));
-        jest.useRealTimers();
+      // Fast-forward time until 30s timeout occurs
+      jest.advanceTimersByTime(30000);
+
+      await expect(responsePromise).rejects.toThrow(expect.stringContaining('timed out'));
+      expect(Logger.warn).toHaveBeenCalledWith(expect.stringContaining(`Request ${expect.any(String)} (action: ${action}) timed out.`));
+      jest.useRealTimers();
     });
   });
 
@@ -251,81 +255,84 @@ describe('MCPClient', () => {
       expect(Logger.info).toHaveBeenCalledWith(expect.stringContaining('Manually closing connection'));
     });
   });
-  
+
   describe('Auto-Reconnection', () => {
-    jest.useFakeTimers();
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
 
     afterEach(() => {
-        jest.clearAllTimers();
-        jest.useRealTimers();
+      jest.useRealTimers();
+      jest.clearAllTimers();
+      jest.useRealTimers();
     });
 
     it('should attempt to reconnect on close if autoReconnect is true', async () => {
-        let openCallback: any, errorCallback: any, closeCallback: any;
-        (mockWebSocketInstance.on as jest.Mock).mockImplementation((event, callback) => {
-            if (event === 'open') openCallback = callback;
-            if (event === 'error') errorCallback = callback;
-            if (event === 'close') closeCallback = callback;
-        });
+      let openCallback: any, errorCallback: any, closeCallback: any;
+      (mockWebSocketInstance.on as jest.Mock).mockImplementation((event, callback) => {
+        if (event === 'open') openCallback = callback;
+        if (event === 'error') errorCallback = callback;
+        if (event === 'close') closeCallback = callback;
+      });
 
-        // Initial connection
-        const connectPromise = client.connect();
-        if (openCallback) openCallback(); // Simulate open
-        await connectPromise;
+      // Initial connection
+      const connectPromise = client.connect();
+      if (openCallback) openCallback(); // Simulate open
+      await connectPromise;
 
-        // Simulate unexpected close
-        if (closeCallback) closeCallback(1006, 'Network lost');
-        
-        expect(Logger.info).toHaveBeenCalledWith(expect.stringContaining('Attempting to reconnect'));
+      // Simulate unexpected close
+      if (closeCallback) closeCallback(1006, 'Network lost');
 
-        // Fast-forward to trigger reconnect attempt
-        jest.advanceTimersByTime(5000); // Default reconnectInterval
+      expect(Logger.info).toHaveBeenCalledWith(expect.stringContaining('Attempting to reconnect'));
 
-        // Expect WebSocket to be called again for reconnection
-        // The first call was for the initial connect, so this should be the second call.
-        expect(WebSocket).toHaveBeenCalledTimes(2); 
+      // Fast-forward to trigger reconnect attempt
+      jest.advanceTimersByTime(5000); // Default reconnectInterval
+
+      // Expect WebSocket to be called again for reconnection
+      // The first call was for the initial connect, so this should be the second call.
+      expect(WebSocket).toHaveBeenCalledTimes(2);
     });
 
     it('should stop reconnecting after maxReconnectAttempts', async () => {
-        client = new MCPClient(serverUrl, true, 2, 1000); // Max 2 attempts, 1s interval
-        let openCallback: any, errorCallback: any, closeCallback: any;
+      client = new MCPClient(serverUrl, true, 2, 1000); // Max 2 attempts, 1s interval
+      let openCallback: any, errorCallback: any, closeCallback: any;
 
-        (WebSocket as jest.Mock).mockImplementation(() => {
-            // Ensure each new WebSocket mock instance gets its own event setup
-            const newWsMock = { ...mockWebSocketInstance, on: jest.fn(), close: jest.fn(), readyState: WebSocket.CONNECTING };
-            (newWsMock.on as jest.Mock).mockImplementation((event, callback) => {
-                if (event === 'open') openCallback = callback;
-                if (event === 'error') errorCallback = callback; // For connect failures
-                if (event === 'close') closeCallback = callback;
-            });
-             // Simulate connection failure for reconnect attempts
-            setTimeout(() => {
-                if (errorCallback) errorCallback(new Error("Simulated connect error"));
-                if (closeCallback) closeCallback(1006); // Also trigger close
-            }, 50);
-            return newWsMock;
+      (WebSocket as jest.Mock).mockImplementation(() => {
+        // Ensure each new WebSocket mock instance gets its own event setup
+        const newWsMock = { ...mockWebSocketInstance, on: jest.fn(), close: jest.fn(), readyState: WebSocket.CONNECTING };
+        (newWsMock.on as jest.Mock).mockImplementation((event, callback) => {
+          if (event === 'open') openCallback = callback;
+          if (event === 'error') errorCallback = callback; // For connect failures
+          if (event === 'close') closeCallback = callback;
         });
-        
-        // Initial connection attempt (which will fail as per mock above)
-        client.connect().catch(() => {}); // Catch initial error
-        
-        // Simulate first failure and trigger close
-        jest.advanceTimersByTime(100); 
+        // Simulate connection failure for reconnect attempts
+        setTimeout(() => {
+          if (errorCallback) errorCallback(new Error("Simulated connect error"));
+          if (closeCallback) closeCallback(1006); // Also trigger close
+        }, 50);
+        return newWsMock;
+      });
 
-        // Reconnect attempt 1
-        jest.advanceTimersByTime(1000); // Interval
-        jest.advanceTimersByTime(100);  // Simulate failure of attempt 1
+      // Initial connection attempt (which will fail as per mock above)
+      client.connect().catch(() => { }); // Catch initial error
 
-        // Reconnect attempt 2
-        jest.advanceTimersByTime(1000); // Interval
-        jest.advanceTimersByTime(100);  // Simulate failure of attempt 2
+      // Simulate first failure and trigger close
+      jest.advanceTimersByTime(100);
 
-        // Should log max attempts reached
-        expect(Logger.error).toHaveBeenCalledWith(expect.stringContaining('Max reconnect attempts (2) reached.'));
-        
-        // Should not try to connect a 4th time (initial + 2 retries)
-        jest.advanceTimersByTime(1000); // Pass another interval
-        expect(WebSocket).toHaveBeenCalledTimes(3); // Initial (1) + Reconnect Attempt 1 (2) + Reconnect Attempt 2 (3)
+      // Reconnect attempt 1
+      jest.advanceTimersByTime(1000); // Interval
+      jest.advanceTimersByTime(100);  // Simulate failure of attempt 1
+
+      // Reconnect attempt 2
+      jest.advanceTimersByTime(1000); // Interval
+      jest.advanceTimersByTime(100);  // Simulate failure of attempt 2
+
+      // Should log max attempts reached
+      expect(Logger.error).toHaveBeenCalledWith(expect.stringContaining('Max reconnect attempts (2) reached.'));
+
+      // Should not try to connect a 4th time (initial + 2 retries)
+      jest.advanceTimersByTime(1000); // Pass another interval
+      expect(WebSocket).toHaveBeenCalledTimes(3); // Initial (1) + Reconnect Attempt 1 (2) + Reconnect Attempt 2 (3)
     });
     jest.useRealTimers();
   });

--- a/packages/plugin-mcp/test/MCPPlugin.test.ts
+++ b/packages/plugin-mcp/test/MCPPlugin.test.ts
@@ -1,0 +1,134 @@
+import { MCPPlugin, MCPPluginConfig } from '../src';
+import { MCPClient } from '../src/MCPClient';
+import { Logger } from '@arifwidianto/msa-core';
+
+// Mock Logger
+jest.mock('@arifwidianto/msa-core', () => ({
+  Logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+// Mock MCPClient
+const mockMCPClientInstance = {
+  connect: jest.fn().mockResolvedValue(undefined),
+  close: jest.fn(),
+  sendRequest: jest.fn(),
+  setOnMessageHandler: jest.fn(),
+};
+jest.mock('../src/MCPClient', () => ({
+  MCPClient: jest.fn(() => mockMCPClientInstance),
+}));
+
+
+describe('MCPPlugin', () => {
+  let plugin: MCPPlugin;
+  const config: MCPPluginConfig = { serverUrl: 'ws://test-server.com/mcp' };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    plugin = new MCPPlugin();
+  });
+
+  describe('Initialization', () => {
+    it('should initialize MCPClient with serverUrl from config', async () => {
+      await plugin.initialize(config);
+      expect(MCPClient).toHaveBeenCalledWith(config.serverUrl, undefined, undefined, undefined); // Check for optional params too
+      expect(Logger.info).toHaveBeenCalledWith(expect.stringContaining(`Initializing with server URL: ${config.serverUrl}`));
+      expect(plugin.getClient()).toBe(mockMCPClientInstance);
+    });
+
+    it('should throw error if serverUrl is not provided', async () => {
+      // Pass an empty object or a config without serverUrl
+      await expect(plugin.initialize({} as MCPPluginConfig)).rejects.toThrow(
+        `${plugin.name}: serverUrl is missing in plugin configuration.`
+      );
+      expect(Logger.error).toHaveBeenCalledWith(expect.stringContaining('serverUrl is required'));
+    });
+    
+    it('should pass through client constructor options', async () => {
+        const fullConfig: MCPPluginConfig = {
+            serverUrl: 'ws://test.com',
+            autoReconnectClient: false,
+            maxReconnectAttemptsClient: 10,
+            reconnectIntervalClient: 2000
+        };
+        await plugin.initialize(fullConfig);
+        expect(MCPClient).toHaveBeenCalledWith(
+            fullConfig.serverUrl,
+            fullConfig.autoReconnectClient,
+            fullConfig.maxReconnectAttemptsClient,
+            fullConfig.reconnectIntervalClient
+        );
+    });
+  });
+
+  describe('Start', () => {
+    it('should call connect on the MCPClient', async () => {
+      await plugin.initialize(config);
+      await plugin.start();
+      expect(mockMCPClientInstance.connect).toHaveBeenCalled();
+      expect(Logger.info).toHaveBeenCalledWith(expect.stringContaining('MCPClient connected successfully.'));
+    });
+
+    it('should throw error if start is called before initialize', async () => {
+      await expect(plugin.start()).rejects.toThrow('Client not initialized.');
+    });
+    
+    it('should handle connection errors from MCPClient on start', async () => {
+        const connectError = new Error("Connection refused");
+        (mockMCPClientInstance.connect as jest.Mock).mockRejectedValueOnce(connectError);
+        await plugin.initialize(config);
+        await expect(plugin.start()).rejects.toThrow(connectError);
+        expect(Logger.error).toHaveBeenCalledWith(expect.stringContaining(`Failed to connect MCPClient: ${connectError.message}`));
+    });
+  });
+
+  describe('Stop', () => {
+    it('should call close on the MCPClient', async () => {
+      await plugin.initialize(config);
+      // await plugin.start(); // Not strictly necessary for stop test if client exists
+      await plugin.stop();
+      expect(mockMCPClientInstance.close).toHaveBeenCalled();
+      expect(Logger.info).toHaveBeenCalledWith(expect.stringContaining('MCPClient connection closed.'));
+    });
+    
+    it('should log if stop is called but no client instance exists (e.g. not initialized)', async () => {
+        await plugin.stop();
+        expect(Logger.info).toHaveBeenCalledWith(`${plugin.name}: No MCPClient instance to stop.`);
+        expect(mockMCPClientInstance.close).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Cleanup', ()_=> {
+    it('should close client and nullify resources', async () => {
+      await plugin.initialize(config);
+      const clientInstance = plugin.getClient(); // Get instance before cleanup
+      
+      await plugin.cleanup();
+      
+      expect(clientInstance.close).toHaveBeenCalled(); // Check on the captured instance
+      expect(Logger.info).toHaveBeenCalledWith(expect.stringContaining('Cleaning up resources.'));
+      // @ts-ignore
+      expect(plugin['client']).toBeNull();
+      // @ts-ignore
+      expect(plugin['config']).toBeNull();
+    });
+  });
+
+  describe('getClient', () => {
+    it('should return the MCPClient instance after initialization', async () => {
+      await plugin.initialize(config);
+      expect(plugin.getClient()).toBe(mockMCPClientInstance);
+    });
+
+    it('should throw error if getClient is called before initialization', () => {
+      expect(() => plugin.getClient()).toThrow(
+        `${plugin.name}: Plugin not initialized or client not available.`
+      );
+    });
+  });
+});

--- a/packages/plugin-mcp/test/MCPPlugin.test.ts
+++ b/packages/plugin-mcp/test/MCPPlugin.test.ts
@@ -103,7 +103,7 @@ describe('MCPPlugin', () => {
     });
   });
 
-  describe('Cleanup', ()_=> {
+  describe('Cleanup', () => {
     it('should close client and nullify resources', async () => {
       await plugin.initialize(config);
       const clientInstance = plugin.getClient(); // Get instance before cleanup

--- a/packages/plugin-mcp/test/MCPServer.test.ts
+++ b/packages/plugin-mcp/test/MCPServer.test.ts
@@ -9,7 +9,7 @@ const mockLoggerInstance = {
   error: jest.fn(),
   debug: jest.fn(),
 };
-const MockLogger = mockLoggerInstance as unknown as Logger; // Cast to Logger type for MCPServer constructor
+const MockLogger = mockLoggerInstance as unknown as typeof Logger; // Cast to Logger type for MCPServer constructor
 
 // Mock ITransport
 const mockTransportInstance: ITransport = {

--- a/packages/plugin-mcp/test/MCPServer.test.ts
+++ b/packages/plugin-mcp/test/MCPServer.test.ts
@@ -1,0 +1,156 @@
+import { MCPServer, MCPRequestHandler } from '../src/MCPServer';
+import { MCPRequest, MCPResponse, MCPContext, MCPMessage } from '../src/mcp-types';
+import { ITransport, Logger } from '@arifwidianto/msa-core';
+
+// Mock Logger from @arifwidianto/msa-core
+const mockLoggerInstance = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+};
+const MockLogger = mockLoggerInstance as unknown as Logger; // Cast to Logger type for MCPServer constructor
+
+// Mock ITransport
+const mockTransportInstance: ITransport = {
+  listen: jest.fn(),
+  send: jest.fn(),
+  onMessage: jest.fn(),
+  close: jest.fn(),
+  // Add sendTo if your ITransport or MCPServer logic specifically uses it
+  // sendTo: jest.fn(), // Example if MCPServer uses a sendTo method
+};
+
+describe('MCPServer', () => {
+  let server: MCPServer;
+  let transportOnMessageCallback: ((message: any, senderId?: string) => void) | null = null;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Capture the onMessage callback when MCPServer is instantiated
+    (mockTransportInstance.onMessage as jest.Mock).mockImplementation((callback) => {
+      transportOnMessageCallback = callback;
+    });
+    server = new MCPServer(mockTransportInstance, MockLogger);
+  });
+
+  it('should initialize and set onMessage handler for transport', () => {
+    expect(mockTransportInstance.onMessage).toHaveBeenCalledWith(expect.any(Function));
+    expect(MockLogger.info).toHaveBeenCalledWith('MCPServer initialized. Listening for messages on the provided transport.');
+  });
+
+  describe('Action Registration', () => {
+    it('should register an action handler', () => {
+      const handler: MCPRequestHandler = jest.fn().mockResolvedValue({ payload: 'test' });
+      server.registerAction('testAction', handler);
+      expect(MockLogger.info).toHaveBeenCalledWith('MCPServer: Registered MCP action handler for: testAction');
+      // @ts-ignore - Access private member for test
+      expect(server['requestHandlers'].has('testAction')).toBe(true);
+    });
+
+    it('should warn when overwriting an existing action handler', () => {
+      const handler1: MCPRequestHandler = jest.fn();
+      const handler2: MCPRequestHandler = jest.fn();
+      server.registerAction('testAction', handler1);
+      server.registerAction('testAction', handler2);
+      expect(MockLogger.warn).toHaveBeenCalledWith('MCPServer: Overwriting handler for action: testAction');
+    });
+    
+    it('should unregister an action handler', () => {
+        const handler: MCPRequestHandler = jest.fn();
+        server.registerAction('testAction', handler);
+        server.unregisterAction('testAction');
+        expect(MockLogger.info).toHaveBeenCalledWith('MCPServer: Unregistered MCP action handler for: testAction');
+        // @ts-ignore
+        expect(server['requestHandlers'].has('testAction')).toBe(false);
+    });
+  });
+
+  describe('Message Handling and Response', () => {
+    const testAction = 'doSomething';
+    let mockActionHandler: jest.Mock<Promise<Partial<MCPResponse>>, [MCPRequest, MCPContext]>;
+
+    const sampleRequest: MCPRequest = {
+      messageId: 'req123',
+      protocolVersion: '1.0',
+      timestamp: new Date().toISOString(),
+      type: 'request',
+      action: testAction,
+      payload: { data: 'sample' },
+      context: { sessionId: 'sess456' },
+    };
+
+    beforeEach(() => {
+      mockActionHandler = jest.fn();
+      server.registerAction(testAction, mockActionHandler);
+    });
+
+    it('should call the correct handler for a registered action and send a success response', async () => {
+      const handlerResponsePayload = { result: 'action completed' };
+      mockActionHandler.mockResolvedValue({ payload: handlerResponsePayload, status: 'success' });
+
+      expect(transportOnMessageCallback).toBeDefined();
+      await transportOnMessageCallback!(JSON.stringify(sampleRequest), 'client1');
+
+      expect(mockActionHandler).toHaveBeenCalledWith(sampleRequest, sampleRequest.context);
+      expect(mockTransportInstance.send).toHaveBeenCalledWith(expect.stringContaining('"status":"success"'));
+      expect(mockTransportInstance.send).toHaveBeenCalledWith(expect.stringContaining(JSON.stringify(handlerResponsePayload)));
+      expect(mockTransportInstance.send).toHaveBeenCalledWith(expect.stringContaining(`"requestId":"${sampleRequest.messageId}"`));
+      expect(MockLogger.info).toHaveBeenCalledWith({ requestId: sampleRequest.messageId, action: sampleRequest.action, senderId: 'client1' }, 'MCPServer: MCP Request received');
+    });
+
+    it('should send an error response if no handler is found for an action', async () => {
+      const unknownActionRequest: MCPRequest = { ...sampleRequest, action: 'unknownAction' };
+      await transportOnMessageCallback!(JSON.stringify(unknownActionRequest));
+
+      expect(mockTransportInstance.send).toHaveBeenCalledWith(expect.stringContaining('"status":"error"'));
+      expect(mockTransportInstance.send).toHaveBeenCalledWith(expect.stringContaining('"code":"NO_HANDLER"'));
+      expect(mockTransportInstance.send).toHaveBeenCalledWith(expect.stringContaining('No handler registered for action: unknownAction'));
+      expect(MockLogger.warn).toHaveBeenCalledWith({ requestId: unknownActionRequest.messageId, action: unknownActionRequest.action }, 'MCPServer: No handler found for action');
+    });
+
+    it('should send an error response if the handler throws an exception', async () => {
+      const errorMessage = 'Handler failed!';
+      mockActionHandler.mockRejectedValue(new Error(errorMessage));
+
+      await transportOnMessageCallback!(JSON.stringify(sampleRequest));
+
+      expect(mockTransportInstance.send).toHaveBeenCalledWith(expect.stringContaining('"status":"error"'));
+      expect(mockTransportInstance.send).toHaveBeenCalledWith(expect.stringContaining('"code":"HANDLER_EXCEPTION"'));
+      expect(mockTransportInstance.send).toHaveBeenCalledWith(expect.stringContaining(errorMessage));
+      expect(MockLogger.error).toHaveBeenCalledWith(expect.objectContaining({ requestId: sampleRequest.messageId, action: sampleRequest.action }), 'MCPServer: Error in request handler');
+    });
+
+    it('should ignore non-request message types', async () => {
+      const nonRequestMessage = { type: 'event', data: 'something happened' };
+      await transportOnMessageCallback!(JSON.stringify(nonRequestMessage));
+
+      expect(mockTransportInstance.send).not.toHaveBeenCalled();
+      expect(MockLogger.warn).toHaveBeenCalledWith({ message: nonRequestMessage }, 'MCPServer: Received non-request message type, ignoring.');
+    });
+
+    it('should handle JSON parsing errors for incoming messages', async () => {
+      const invalidJsonMessage = "{ not json";
+      await transportOnMessageCallback!(invalidJsonMessage);
+
+      expect(mockTransportInstance.send).not.toHaveBeenCalled(); // Should not send if can't parse request ID etc.
+      expect(MockLogger.error).toHaveBeenCalledWith(expect.objectContaining({ rawMessage: invalidJsonMessage }), 'MCPServer: Error processing raw message.');
+    });
+    
+    it('should use senderId with transport.sendTo if available and method exists', async () => {
+        const mockSendToTransport = { ...mockTransportInstance, sendTo: jest.fn() };
+        server = new MCPServer(mockSendToTransport, MockLogger); // Re-init server with new transport
+        
+        // Need to re-capture the onMessage callback for the new server instance
+        const newTransportOnMessageCallback = (mockSendToTransport.onMessage as jest.Mock).mock.calls[0][0];
+
+        mockActionHandler.mockResolvedValue({ payload: "data" });
+        server.registerAction(testAction, mockActionHandler); // Re-register action
+
+        await newTransportOnMessageCallback(JSON.stringify(sampleRequest), 'clientXYZ');
+        
+        expect(mockSendToTransport.sendTo).toHaveBeenCalledWith('clientXYZ', expect.stringContaining(`"requestId":"${sampleRequest.messageId}"`));
+        expect(mockSendToTransport.send).not.toHaveBeenCalled(); // Ensure send was not called
+    });
+  });
+});

--- a/packages/plugin-mcp/tsconfig.build.json
+++ b/packages/plugin-mcp/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
+  "exclude": ["node_modules", "dist", "test"]
+}

--- a/packages/plugin-mcp/tsconfig.json
+++ b/packages/plugin-mcp/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["src"]
+}

--- a/packages/plugin-messagebroker/README.md
+++ b/packages/plugin-messagebroker/README.md
@@ -1,0 +1,190 @@
+# MSA Message Broker Plugin (@arifwidianto/msa-plugin-messagebroker)
+
+This plugin provides message broker capabilities for the MSA (Microservice Architecture) framework, supporting both RabbitMQ and Redis Pub/Sub. It allows services to publish messages to and subscribe to messages from a message queue or pub/sub channels.
+
+## Features
+
+*   **Multiple Broker Support**:
+    *   **RabbitMQ Integration**: Connects to a RabbitMQ server, publishes messages, and subscribes to queues using `amqplib`.
+    *   **Redis Pub/Sub Integration**: Connects to a Redis server and uses its Pub/Sub mechanism using `redis` (v4).
+*   **Internal Service Logic**:
+    *   `RabbitMQService`: Encapsulates `amqplib` logic for RabbitMQ.
+    *   `RedisPubSubService`: Encapsulates `redis` client logic for Pub/Sub.
+    *   Both services handle connection management, publishing, subscribing with multiple handlers, and graceful closing.
+*   **`MessageBrokerPlugin`**: Implements `IPlugin` and `ITransport` from `@arifwidianto/msa-core`.
+    *   Manages the lifecycle of the chosen broker service (`RabbitMQService` or `RedisPubSubService`).
+    *   Maps `ITransport` methods (`listen`, `send`, `onMessage`, `close`) to the active broker's operations.
+*   **Configurable**: Supports broker-specific configurations (URLs, defaults, prefixes).
+
+## Installation
+
+This plugin is typically used as part of an MSA framework monorepo. Ensure it's listed as a dependency. Dependencies (`amqplib`, `redis`, `@arifwidianto/msa-core`) and dev dependencies (`@types/amqplib`) should be managed by the monorepo's package manager.
+
+```bash
+# If managing dependencies manually:
+npm install amqplib redis @arifwidianto/msa-plugin-messagebroker @arifwidianto/msa-core
+npm install -D @types/amqplib # @types/redis not usually needed for redis v4+
+# or
+yarn add amqplib redis @arifwidianto/msa-plugin-messagebroker @arifwidianto/msa-core
+yarn add -D @types/amqplib
+```
+
+## Configuration
+
+The `MessageBrokerPlugin` is configured during service initialization. You must specify `clientType` as either `'rabbitmq'` or `'redis'` and provide the corresponding configuration object.
+
+### `MessageBrokerPluginConfig`
+
+```typescript
+import { PluginConfig } from '@arifwidianto/msa-core';
+
+// Configuration for RabbitMQ
+export interface RabbitMQConfig {
+  url: string; // e.g., 'amqp://guest:guest@localhost:5672/'
+  defaultExchange?: { 
+    name: string; 
+    type?: 'direct' | 'topic' | 'headers' | 'fanout';
+    options?: object; // amqplib assertExchange options (e.g., { durable: true })
+  };
+  defaultQueue?: { 
+    name: string; 
+    options?: object; // amqplib assertQueue options (e.g., { durable: true })
+  };
+}
+
+// Configuration for Redis Pub/Sub
+export interface RedisConfig {
+  url?: string; // e.g., 'redis://localhost:6379'
+  host?: string; // Alternative to URL if not using full URL format
+  port?: number;
+  password?: string;
+  defaultChannelPrefix?: string; // Optional: e.g., 'msa-app:' prepended to channel names
+}
+
+// Main plugin configuration
+export interface MessageBrokerPluginConfig extends PluginConfig {
+  clientType: 'rabbitmq' | 'redis'; // Specify which broker to use
+  rabbitmq?: RabbitMQConfig;     // Provide if clientType is 'rabbitmq'
+  redis?: RedisConfig;         // Provide if clientType is 'redis'
+}
+```
+
+### Environment Variables
+
+It's highly recommended to provide connection URLs and other sensitive details (like passwords) via environment variables, using `@arifwidianto/msa-core`'s `Config` class.
+
+Examples:
+*   `RABBITMQ_URL="amqp://user:pass@your-rabbitmq-server:5672"`
+*   `REDIS_URL="redis://:yourpassword@your-redis-server:6379"`
+
+### Example Service Setup
+
+```typescript
+// In your main service setup
+import { Service, Config, Logger, Message, MessageHandler } from '@arifwidianto/msa-core';
+import { MessageBrokerPlugin, MessageBrokerPluginConfig } from '@arifwidianto/msa-plugin-messagebroker';
+
+const service = new Service(); // Assume Service has getLogger method
+const mbPlugin = new MessageBrokerPlugin();
+
+// --- RabbitMQ Configuration Example ---
+const rabbitMqPluginConfig: MessageBrokerPluginConfig = {
+  clientType: 'rabbitmq',
+  rabbitmq: {
+    url: Config.get('RABBITMQ_URL', 'amqp://localhost'),
+    defaultExchange: { name: 'app_default_exchange', type: 'topic' },
+    defaultQueue: { name: 'app_default_queue' }
+  }
+};
+
+// --- Redis Configuration Example ---
+const redisPluginConfig: MessageBrokerPluginConfig = {
+  clientType: 'redis',
+  redis: {
+    url: Config.get('REDIS_URL', 'redis://localhost:6379'),
+    defaultChannelPrefix: 'myapp:'
+  }
+};
+
+// Choose one configuration to use:
+const chosenConfig = Config.get('BROKER_TYPE') === 'redis' ? redisPluginConfig : rabbitMqPluginConfig;
+
+// Ensure URL is found for the chosen client type
+let brokerUrlValid = false;
+if (chosenConfig.clientType === 'rabbitmq' && chosenConfig.rabbitmq?.url) {
+    brokerUrlValid = true;
+} else if (chosenConfig.clientType === 'redis' && (chosenConfig.redis?.url || (chosenConfig.redis?.host && chosenConfig.redis?.port))) {
+    brokerUrlValid = true;
+}
+
+if (!brokerUrlValid) {
+  Logger.error("Message Broker URL not found or client type invalid. Plugin will not work.");
+  // Handle missing URL appropriately
+} else {
+  service.registerPlugin(mbPlugin);
+}
+
+// Initialize and start the service
+async function main() {
+  await mbPlugin.initialize(chosenConfig, service); // Pass service for scoped logger
+  await service.startService(); // This calls mbPlugin.start() which connects the chosen broker service
+
+  // Now MessageBrokerPlugin ITransport methods can be used.
+  
+  if (chosenConfig.clientType === 'rabbitmq') {
+    // Example: Subscribe to a RabbitMQ queue
+    const subId = await mbPlugin.listen('my_rabbit_queue', (msgContent: Message) => {
+      Logger.info(`RabbitMQ message on my_rabbit_queue: ${msgContent}`);
+    });
+    Logger.info(`Subscribed to 'my_rabbit_queue'. Sub ID: ${subId}`);
+    
+    // Example: Publish to RabbitMQ
+    await mbPlugin.send({ data: "Hello RabbitMQ!" }, 'my.routing.key');
+  } else if (chosenConfig.clientType === 'redis') {
+    // Example: Subscribe to a Redis channel
+    const subId = await mbPlugin.listen('my_redis_channel', (msgContent: Message) => {
+      Logger.info(`Redis message on my_redis_channel: ${msgContent}`);
+    });
+    Logger.info(`Subscribed to 'my_redis_channel'. Sub ID: ${subId}`);
+
+    // Example: Publish to Redis channel
+    await mbPlugin.send({ data: "Hello Redis!" }, 'my_redis_channel'); // For Redis, second arg is channel
+  }
+}
+
+main().catch(error => Logger.error({ msg: "Service failed to start or run", error }));
+```
+
+## `ITransport` Implementation Details
+
+The `MessageBrokerPlugin` implements the `ITransport` interface from `@arifwidianto/msa-core`. Its behavior adapts based on the configured `clientType`.
+
+*   **`listen(topicOrQueueName: string, handler?: MessageHandler): Promise<string | void>`**:
+    *   **RabbitMQ**: Subscribes to the specified `queueName`. The `handler` is called for each message. Returns a `subscriptionId`.
+    *   **Redis**: Subscribes to the specified `channelName` (prefixed by `defaultChannelPrefix` if configured). The `handler` is called for each message. Returns a `subscriptionId`.
+    *   A unique `subscriptionId` is generated by the plugin for each call to `listen` that successfully establishes a handler. This ID is used with `close(subscriptionId)` to remove a specific handler.
+
+*   **`send(message: Message, topicOrRoutingKey?: string, exchange?: string): Promise<void>`**:
+    *   **RabbitMQ**: Publishes the `message`. `topicOrRoutingKey` is the RabbitMQ `routingKey`. `exchange` is the target exchange (uses `defaultExchange` if `exchange` is null/undefined).
+    *   **Redis**: Publishes the `message`. `topicOrRoutingKey` **must** be provided and is used as the Redis `channelName`. The `exchange` argument is ignored for Redis.
+    *   The `message` can be a `string`, `Buffer`, or a JavaScript `object` (which will be JSON-stringified before sending).
+
+*   **`onMessage(handler: MessageHandler, topicOrQueueName?: string): void`**:
+    *   A convenience method that calls `this.listen(targetTopicOrQueue, handler)`.
+    *   **RabbitMQ**: If `topicOrQueueName` is not provided, it uses `defaultQueue.name` from the RabbitMQ configuration.
+    *   **Redis**: If `topicOrQueueName` is not provided, it might use a default channel (e.g., `defaultChannelPrefix` + 'default'). It's generally better to provide an explicit channel for Redis.
+
+*   **`close(subscriptionId?: string): Promise<void>`**:
+    *   If a `subscriptionId` (obtained from `listen`) is provided:
+        *   **RabbitMQ**: Attempts to remove the specific handler associated with that `subscriptionId`. If it's the last handler for a given RabbitMQ consumer tag, the consumer itself might be cancelled.
+        *   **Redis**: Attempts to remove the specific handler. If it's the last handler for a given Redis channel, the client unsubscribes from that channel.
+    *   If no `subscriptionId` is provided: Closes the entire connection for the active broker (RabbitMQ or Redis), stopping all subscriptions and publishing capabilities for this plugin instance.
+
+## Choosing Between RabbitMQ and Redis
+
+*   **RabbitMQ**: A feature-rich message broker with support for complex routing (exchanges, queues, bindings), message persistence, acknowledgements, and more. Suitable for scenarios requiring high reliability, guaranteed delivery, and complex message workflows.
+*   **Redis Pub/Sub**: A simpler, very fast publish/subscribe mechanism. Messages are "fire and forget" – if no subscribers are listening when a message is published, the message is lost. Good for real-time notifications, event broadcasting where some message loss is acceptable, or transient messaging.
+
+Select the `clientType` and configure accordingly based on your application's needs.
+
+This plugin provides a versatile foundation for integrating message-driven patterns into your MSA services. Remember to handle message (de)serialization appropriately for complex objects.

--- a/packages/plugin-messagebroker/jest.config.js
+++ b/packages/plugin-messagebroker/jest.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+  displayName: 'plugin-messagebroker',
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/test/**/*.test.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.json' // This should point to packages/plugin-messagebroker/tsconfig.json
+    }
+  },
+  moduleNameMapper: {
+    // If you use path aliases in tsconfig.json that Jest needs to understand
+    // e.g., "^@core/(.*)$": "<rootDir>/../core/src/$1"
+    // For this plugin, we need to ensure it can find @arifwidianto/msa-core
+    '^@arifwidianto/msa-core$': '<rootDir>/../core/src/index.ts'
+  }
+};

--- a/packages/plugin-messagebroker/package.json
+++ b/packages/plugin-messagebroker/package.json
@@ -4,7 +4,14 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc -p tsconfig.build.json"
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rimraf dist",
+    "dev": "tsc -p tsconfig.build.json --watch",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage",
+    "lint": "eslint src/**/*.ts",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@arifwidianto/msa-core": "0.1.0",
@@ -13,7 +20,15 @@
   },
   "devDependencies": {
     "typescript": "^5.4.5",
-    "@types/amqplib": "^0.10.5"
+    "@types/amqplib": "^0.10.5",
+    "rimraf": "^5.0.5",
+    "jest": "^29.7.0",
+    "@types/jest": "^29.5.12",
+    "eslint": "^8.52.0",
+    "@typescript-eslint/eslint-plugin": "^6.9.1",
+    "@typescript-eslint/parser": "^6.9.1",
+    "ts-jest": "^29.1.2",
+    "redis-mock": "^0.56.3"
   },
   "peerDependencies": {
     "@arifwidianto/msa-core": "0.1.0"

--- a/packages/plugin-messagebroker/package.json
+++ b/packages/plugin-messagebroker/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@arifwidianto/msa-plugin-messagebroker",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json"
+  },
+  "dependencies": {
+    "@arifwidianto/msa-core": "0.1.0",
+    "amqplib": "^0.10.4",
+    "redis": "^4.6.13"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5",
+    "@types/amqplib": "^0.10.5"
+  },
+  "peerDependencies": {
+    "@arifwidianto/msa-core": "0.1.0"
+  }
+}

--- a/packages/plugin-messagebroker/src/MessageBrokerPlugin.ts
+++ b/packages/plugin-messagebroker/src/MessageBrokerPlugin.ts
@@ -1,0 +1,198 @@
+import { IPlugin, ITransport, Logger, Service, Message, MessageHandler, PluginConfig } from '@arifwidianto/msa-core';
+import { MessageBrokerPluginConfig, RabbitMQConfig, RedisConfig } from './MessageBrokerPluginConfig'; // Import RedisConfig
+import { RabbitMQService } from './rabbitmq.service';
+import { RedisPubSubService } from './redis.service'; // Import RedisPubSubService
+
+export class MessageBrokerPlugin implements IPlugin, ITransport {
+  name = 'msa-plugin-messagebroker';
+  version = '0.1.0';
+  dependencies: string[] = [];
+  
+  private config!: MessageBrokerPluginConfig;
+  private logger!: Logger;
+  private rabbitmqService?: RabbitMQService;
+  private redisService?: RedisPubSubService;
+
+  // Store consumerTags/subscriptionIds to manage subscriptions via ITransport methods
+  // For RabbitMQ, value is { queueName, consumerTag }
+  // For Redis, value is { channelName, isRedis: true } (consumerTag concept doesn't directly map)
+  private transportSubscriptions: Map<string, { type: 'rabbitmq' | 'redis', queueOrChannelName: string, rabbitConsumerTag?: string, specificHandler?: MessageHandler }> = new Map();
+  private nextSubscriptionId = 0;
+
+
+  async initialize(config: MessageBrokerPluginConfig, service?: Service): Promise<void> {
+    this.config = config;
+    
+    if (service && typeof service.getLogger === 'function') {
+      this.logger = service.getLogger(this.name);
+    } else {
+      this.logger = Logger; 
+      this.logger.warn(`${this.name}: Service instance or getLogger method not provided to initialize. Using global Logger.`);
+    }
+
+    if (config.clientType === 'rabbitmq' && config.rabbitmq) {
+      this.logger.info('RabbitMQ client type configured. Initializing RabbitMQService.');
+      this.rabbitmqService = new RabbitMQService(config.rabbitmq, this.logger);
+    } else if (config.clientType === 'redis' && config.redis) {
+      this.logger.info('Redis client type configured. Initializing RedisPubSubService.');
+      this.redisService = new RedisPubSubService(config.redis, this.logger);
+    } else {
+      this.logger.warn('Message broker clientType not configured properly or unknown.');
+    }
+  }
+
+  async start(): Promise<void> {
+    this.logger.info(`${this.name} starting...`);
+    if (this.rabbitmqService) {
+      try {
+        await this.rabbitmqService.connect();
+        this.logger.info('RabbitMQService connected successfully.');
+      } catch (error) {
+        this.logger.error({ error }, `${this.name}: Failed to connect RabbitMQService during start.`);
+        throw error;
+      }
+    }
+    if (this.redisService) {
+      try {
+        await this.redisService.connect();
+        this.logger.info('RedisPubSubService connected successfully.');
+      } catch (error) {
+        this.logger.error({ error }, `${this.name}: Failed to connect RedisPubSubService during start.`);
+        throw error;
+      }
+    }
+  }
+
+  async stop(): Promise<void> {
+    this.logger.info(`${this.name} stopping...`);
+    if (this.rabbitmqService) {
+      await this.rabbitmqService.close();
+      this.logger.info('RabbitMQService connection closed.');
+    }
+    if (this.redisService) {
+      await this.redisService.close();
+      this.logger.info('RedisPubSubService connection closed.');
+    }
+  }
+  
+  async cleanup(): Promise<void> {
+    this.logger.info(`${this.name} cleaning up...`);
+    if (this.rabbitmqService) {
+      await this.rabbitmqService.close();
+      this.rabbitmqService = undefined;
+    }
+    if (this.redisService) {
+      await this.redisService.close();
+      this.redisService = undefined;
+    }
+    this.transportSubscriptions.clear();
+    this.logger.info(`${this.name} cleanup complete.`);
+  }
+
+  // --- ITransport implementation ---
+
+  async listen(topicOrQueueName: string, handler?: MessageHandler): Promise<string | void> {
+    if (!handler) {
+       this.logger.warn(`No handler provided for listen/subscribe on: ${topicOrQueueName}. Subscription not created.`);
+       return;
+    }
+    
+    const subscriptionId = `msa-sub-${this.nextSubscriptionId++}`;
+
+    if (this.rabbitmqService) {
+      try {
+        const consumerTag = await this.rabbitmqService.subscribe(topicOrQueueName, handler);
+        if (consumerTag) {
+            this.transportSubscriptions.set(subscriptionId, { type: 'rabbitmq', queueOrChannelName: topicOrQueueName, rabbitConsumerTag: consumerTag, specificHandler: handler });
+            this.logger.info(`ITransport/RabbitMQ: Subscribed to queue '${topicOrQueueName}' with subscriptionId '${subscriptionId}' (consumerTag: ${consumerTag}).`);
+            return subscriptionId;
+        } else {
+            // This branch might occur if RabbitMQService's subscribe decides not to return a new consumerTag (e.g. shared consumer)
+            // For ITransport, we still want a unique ID to manage this specific handler.
+            this.transportSubscriptions.set(subscriptionId, { type: 'rabbitmq', queueOrChannelName: topicOrQueueName, specificHandler: handler });
+            this.logger.info(`ITransport/RabbitMQ: Added handler to queue '${topicOrQueueName}' with subscriptionId '${subscriptionId}' (likely shared consumer).`);
+            return subscriptionId;
+        }
+      } catch (error) {
+        this.logger.error({ error, queue: topicOrQueueName }, `ITransport/RabbitMQ: Error subscribing to queue '${topicOrQueueName}'.`);
+        throw error;
+      }
+    } else if (this.redisService) {
+      try {
+        // RedisPubSubService.subscribe returns the full channel name, which we can use directly or wrap.
+        // For consistency with ITransport, we'll use our generated subscriptionId.
+        await this.redisService.subscribe(topicOrQueueName, handler);
+        this.transportSubscriptions.set(subscriptionId, { type: 'redis', queueOrChannelName: topicOrQueueName, specificHandler: handler });
+        this.logger.info(`ITransport/Redis: Subscribed to channel '${topicOrQueueName}' with subscriptionId '${subscriptionId}'.`);
+        return subscriptionId;
+      } catch (error) {
+        this.logger.error({ error, channel: topicOrQueueName }, `ITransport/Redis: Error subscribing to channel '${topicOrQueueName}'.`);
+        throw error;
+      }
+    } else {
+      this.logger.error('ITransport: No message broker service (RabbitMQ/Redis) available. Cannot subscribe.');
+      throw new Error('No message broker service available for listen/subscribe.');
+    }
+  }
+
+  async send(message: Message, topicOrRoutingKey?: string, exchange?: string): Promise<void> {
+    if (this.rabbitmqService) {
+      const targetExchange = exchange || this.config.rabbitmq?.defaultExchange?.name || '';
+      const targetRoutingKey = topicOrRoutingKey || '';
+      await this.rabbitmqService.publish(targetExchange, targetRoutingKey, message);
+      this.logger.debug(`ITransport/RabbitMQ: Message sent to exchange '${targetExchange}' with routingKey '${targetRoutingKey}'.`);
+    } else if (this.redisService) {
+      if (!topicOrRoutingKey) {
+        this.logger.error('ITransport/Redis: Redis publish requires a channel name (passed as topicOrRoutingKey).');
+        throw new Error('Redis publish requires a channel name.');
+      }
+      await this.redisService.publish(topicOrRoutingKey, message);
+      this.logger.debug(`ITransport/Redis: Message sent to channel '${topicOrRoutingKey}'.`);
+    } else {
+      this.logger.error('ITransport: No message broker service available. Cannot send message.');
+      throw new Error('No message broker service available for send.');
+    }
+  }
+  
+  onMessage(handler: MessageHandler, topicOrQueueName?: string): void {
+     const targetTopicOrQueue = topicOrQueueName || 
+        (this.config.clientType === 'rabbitmq' ? this.config.rabbitmq?.defaultQueue?.name : undefined) ||
+        (this.config.clientType === 'redis' ? (this.redisService ? this.redisService['getFullChannelName']('default') : 'default') : undefined);
+        // Note: Accessing private getFullChannelName is a bit of a hack for default; consider public default channel name property in RedisService.
+
+     if (targetTopicOrQueue) {
+        this.listen(targetTopicOrQueue, handler).catch(err => {
+            this.logger.error({err, topicOrQueue: targetTopicOrQueue}, `ITransport.onMessage: Error setting up listener.`);
+        });
+     } else {
+        this.logger.error('ITransport.onMessage: Cannot call onMessage without a topic/queueName or default configured for the active client type.');
+     }
+  }
+
+  async close(subscriptionId?: string): Promise<void> {
+    if (subscriptionId) {
+      const subInfo = this.transportSubscriptions.get(subscriptionId);
+      if (!subInfo) {
+        this.logger.warn(`ITransport.close: No active subscription found for ID '${subscriptionId}'. No action taken.`);
+        return;
+      }
+
+      if (subInfo.type === 'rabbitmq' && this.rabbitmqService) {
+        // RabbitMQService.unsubscribe can take specific handler or consumerTag
+        await this.rabbitmqService.unsubscribe(subInfo.queueOrChannelName, subInfo.specificHandler, subInfo.rabbitConsumerTag);
+        this.logger.info(`ITransport/RabbitMQ: Unsubscribed from queue '${subInfo.queueOrChannelName}' for subscriptionId '${subscriptionId}'.`);
+      } else if (subInfo.type === 'redis' && this.redisService) {
+        // RedisPubSubService.unsubscribe takes channelName and optional specific handler
+        await this.redisService.unsubscribe(subInfo.queueOrChannelName, subInfo.specificHandler);
+        this.logger.info(`ITransport/Redis: Unsubscribed from channel '${subInfo.queueOrChannelName}' for subscriptionId '${subscriptionId}'.`);
+      }
+      this.transportSubscriptions.delete(subscriptionId);
+    } else {
+      // General close: shut down the entire connection for the active broker.
+      this.logger.info('ITransport.close: No specific subscriptionId provided. Closing entire message broker connection for this plugin.');
+      if (this.rabbitmqService) await this.rabbitmqService.close();
+      if (this.redisService) await this.redisService.close();
+      this.transportSubscriptions.clear();
+    }
+  }
+}

--- a/packages/plugin-messagebroker/src/MessageBrokerPluginConfig.ts
+++ b/packages/plugin-messagebroker/src/MessageBrokerPluginConfig.ts
@@ -1,0 +1,21 @@
+import { PluginConfig } from '@arifwidianto/msa-core';
+
+export interface RabbitMQConfig {
+  url: string; // e.g., 'amqp://localhost'
+  defaultExchange?: { name: string; type?: string; options?: object }; // Optional default exchange
+  defaultQueue?: { name: string; options?: object }; // Optional default queue for simple scenarios
+}
+
+export interface RedisConfig {
+  url?: string; // e.g., 'redis://localhost:6379'
+  host?: string; // Alternative to URL
+  port?: number;
+  password?: string;
+  defaultChannelPrefix?: string; // e.g., 'msa-app:'
+}
+
+export interface MessageBrokerPluginConfig extends PluginConfig {
+  clientType: 'rabbitmq' | 'redis'; // Add 'redis'
+  rabbitmq?: RabbitMQConfig;
+  redis?: RedisConfig;
+}

--- a/packages/plugin-messagebroker/src/index.ts
+++ b/packages/plugin-messagebroker/src/index.ts
@@ -1,0 +1,4 @@
+export { MessageBrokerPlugin } from './MessageBrokerPlugin';
+export { MessageBrokerPluginConfig, RabbitMQConfig, RedisConfig } from './MessageBrokerPluginConfig'; // Add RedisConfig
+export { RabbitMQService } from './rabbitmq.service';
+export { RedisPubSubService } from './redis.service'; // Add RedisPubSubService

--- a/packages/plugin-messagebroker/src/rabbitmq.service.ts
+++ b/packages/plugin-messagebroker/src/rabbitmq.service.ts
@@ -1,0 +1,216 @@
+import amqp from 'amqplib';
+import { Logger, Message, MessageHandler } from '@arifwidianto/msa-core';
+import { RabbitMQConfig } from './MessageBrokerPluginConfig';
+
+export class RabbitMQService {
+  private connection: amqp.Connection | null = null;
+  private channel: amqp.Channel | null = null;
+  private config: RabbitMQConfig;
+  private logger: Logger;
+  private messageHandlers: Map<string, { handlers: MessageHandler[], consumerTag: string | null }> = new Map(); // queueName -> {handlers, consumerTag}
+
+
+  constructor(config: RabbitMQConfig, logger: Logger) {
+    this.config = config;
+    this.logger = logger;
+  }
+
+  async connect(): Promise<void> {
+    try {
+      this.connection = await amqp.connect(this.config.url);
+      this.logger.info('Successfully connected to RabbitMQ server.');
+      
+      this.connection.on('error', (err) => {
+        this.logger.error({ err }, 'RabbitMQ connection error');
+        // Handle connection error, e.g., attempt reconnect or cleanup
+        this.connection = null; // Mark as disconnected
+        this.channel = null;
+      });
+
+      this.connection.on('close', (err) => {
+        this.logger.info({ err }, 'RabbitMQ connection closed.');
+        this.connection = null; // Mark as disconnected
+        this.channel = null;
+        // Optionally attempt to reconnect here
+      });
+      
+      this.channel = await this.connection.createChannel();
+      this.logger.info('RabbitMQ channel created.');
+
+      this.channel.on('error', (err) => {
+        this.logger.error({ err }, 'RabbitMQ channel error');
+        this.channel = null; // Mark channel as unusable
+      });
+
+      this.channel.on('close', () => {
+        this.logger.info('RabbitMQ channel closed.');
+        this.channel = null;
+      });
+
+      if (this.config.defaultExchange) {
+        await this.channel.assertExchange(
+            this.config.defaultExchange.name, 
+            this.config.defaultExchange.type || 'direct', 
+            this.config.defaultExchange.options || { durable: true }
+        );
+        this.logger.info(`Default exchange "${this.config.defaultExchange.name}" asserted.`);
+      }
+
+      if (this.config.defaultQueue) {
+         await this.channel.assertQueue(
+            this.config.defaultQueue.name, 
+            this.config.defaultQueue.options || { durable: true }
+        );
+        this.logger.info(`Default queue "${this.config.defaultQueue.name}" asserted.`);
+
+         if(this.config.defaultExchange) { // Bind default queue to default exchange
+            await this.channel.bindQueue(this.config.defaultQueue.name, this.config.defaultExchange.name, ''); // Empty routing key for default
+            this.logger.info(`Default queue "${this.config.defaultQueue.name}" bound to default exchange "${this.config.defaultExchange.name}".`);
+         }
+      }
+    } catch (error) {
+      this.logger.error({ error }, 'Failed to connect to RabbitMQ or setup defaults');
+      throw error;
+    }
+  }
+
+  async publish(exchange: string, routingKey: string, content: Buffer | string | object, options?: amqp.Options.Publish): Promise<void> {
+    if (!this.channel) {
+        this.logger.error('RabbitMQ channel not available. Cannot publish message.');
+        throw new Error('RabbitMQ channel not available.');
+    }
+    const bufferContent = Buffer.isBuffer(content) ? content : Buffer.from(typeof content === 'object' ? JSON.stringify(content) : content);
+    
+    try {
+        // publish returns a boolean indicating if the message was enqueued (if not, means backpressure)
+        const success = this.channel.publish(exchange, routingKey, bufferContent, options);
+        if (success) {
+            this.logger.debug({ exchange, routingKey, options }, 'Message published to RabbitMQ.');
+        } else {
+            this.logger.warn({ exchange, routingKey, options }, 'RabbitMQ publish buffer is full. Message was not published.');
+            // Implement retry logic or backpressure handling if necessary
+        }
+    } catch (error) {
+        this.logger.error({ error, exchange, routingKey }, 'Error publishing message to RabbitMQ.');
+        throw error;
+    }
+  }
+
+  async subscribe(queueName: string, onMessageCallback: MessageHandler, options?: amqp.Options.Consume): Promise<string | null> {
+    if (!this.channel) {
+        this.logger.error('RabbitMQ channel not available. Cannot subscribe to queue.');
+        throw new Error('RabbitMQ channel not available.');
+    }
+    
+    const queueData = this.messageHandlers.get(queueName);
+
+    if (queueData && queueData.handlers.length > 0) {
+        // Already consuming on this queue, just add the handler
+        queueData.handlers.push(onMessageCallback);
+        this.logger.info(`Added new handler to existing subscription on queue: ${queueName}`);
+        return queueData.consumerTag; // Return existing consumerTag
+    }
+    
+    // New subscription for this queue
+    await this.channel.assertQueue(queueName, this.config.defaultQueue?.options || { durable: true }); // Ensure queue exists
+    
+    const { consumerTag } = await this.channel.consume(queueName, (msg) => {
+      if (msg) {
+        const messageContent: Message = msg.content.toString(); // Or parse if JSON, e.g. JSON.parse(msg.content.toString())
+        const currentQueueData = this.messageHandlers.get(queueName);
+        if (currentQueueData) {
+            currentQueueData.handlers.forEach(handler => {
+                try {
+                    handler(messageContent);
+                } catch (handlerError) {
+                    this.logger.error({ error: handlerError, queueName, messageId: msg.properties.messageId }, 'Error in message handler for queue');
+                    // Optionally, decide if message should be nack'd based on handler error
+                }
+            });
+        }
+        if (!(options && options.noAck)) { // Only ack if noAck is not true
+            this.channel?.ack(msg); 
+        }
+      }
+    }, options || { noAck: false }); // Default to manual ack
+
+    this.messageHandlers.set(queueName, { handlers: [onMessageCallback], consumerTag });
+    this.logger.info(`Subscribed to RabbitMQ queue: ${queueName} with consumerTag: ${consumerTag}`);
+    return consumerTag;
+  }
+  
+  async unsubscribe(queueName: string, specificHandler?: MessageHandler, consumerTagToCancel?: string): Promise<void> {
+    if (!this.channel) {
+        this.logger.warn('RabbitMQ channel not available. Cannot unsubscribe.');
+        return;
+    }
+
+    const queueData = this.messageHandlers.get(queueName);
+    if (!queueData) {
+      this.logger.warn(`No active subscription found for queue: ${queueName} to unsubscribe from.`);
+      return;
+    }
+
+    if (specificHandler) {
+        const index = queueData.handlers.indexOf(specificHandler);
+        if (index > -1) {
+            queueData.handlers.splice(index, 1);
+            this.logger.info(`Handler removed for queue: ${queueName}`);
+        }
+    } else {
+        // If no specific handler, assume intent is to clear all handlers for this queue,
+        // effectively stopping message processing for this instance, and cancel the consumer.
+        queueData.handlers = [];
+    }
+
+    // If there are no more handlers for this queue, or if a consumerTag was explicitly passed for cancellation
+    const resolvedConsumerTag = consumerTagToCancel || queueData.consumerTag;
+    if ((queueData.handlers.length === 0 || consumerTagToCancel) && resolvedConsumerTag) {
+      try {
+        await this.channel.cancel(resolvedConsumerTag);
+        this.logger.info(`Consumer (tag: ${resolvedConsumerTag}) cancelled for RabbitMQ queue: ${queueName}`);
+        this.messageHandlers.delete(queueName); // Remove entry for queue
+      } catch (error) {
+        this.logger.error({ error, queueName, consumerTag: resolvedConsumerTag }, 'Error cancelling RabbitMQ consumer');
+        // Potentially, the consumerTag is invalid or channel is closed.
+      }
+    } else if (queueData.handlers.length > 0) {
+        this.logger.info(`Subscription to queue ${queueName} still active as other handlers remain.`);
+    }
+  }
+
+  async close(): Promise<void> {
+    try {
+      if (this.channel) {
+        // Attempt to cancel all active consumers managed by this service instance
+        for (const [queueName, data] of this.messageHandlers) {
+            if (data.consumerTag) {
+                try {
+                    await this.channel.cancel(data.consumerTag);
+                    this.logger.info(`Consumer (tag: ${data.consumerTag}) cancelled for queue ${queueName} during close.`);
+                } catch (cancelError) {
+                    this.logger.error({ error: cancelError, queueName, consumerTag: data.consumerTag }, 'Error cancelling consumer during close.');
+                }
+            }
+        }
+        this.messageHandlers.clear();
+
+        await this.channel.close();
+        this.logger.info('RabbitMQ channel closed.');
+        this.channel = null;
+      }
+    } catch (error) {
+        this.logger.error({ error }, 'Error closing RabbitMQ channel.');
+    }
+
+    try {
+      if (this.connection) {
+        await this.connection.close();
+        this.logger.info('RabbitMQ connection closed.');
+        this.connection = null;
+      }
+    } catch (error) {
+        this.logger.error({ error }, 'Error closing RabbitMQ connection.');
+    }
+  }
+}

--- a/packages/plugin-messagebroker/src/redis.service.ts
+++ b/packages/plugin-messagebroker/src/redis.service.ts
@@ -1,0 +1,193 @@
+import { createClient, RedisClientType, RedisClientOptions } from 'redis';
+import { Logger, Message, MessageHandler } from '@arifwidianto/msa-core';
+import { RedisConfig } from './MessageBrokerPluginConfig';
+
+export class RedisPubSubService {
+  private publisher: RedisClientType;
+  private subscriber: RedisClientType; // Redis requires separate clients for pub and sub operations when sub is active
+  private config: RedisConfig;
+  private logger: Logger;
+  private messageHandlers: Map<string, MessageHandler[]> = new Map(); // channelName -> handlers
+  private activeRedisSubscriptions: Map<string, boolean> = new Map(); // Tracks if a channel has an active Redis client subscription
+
+  constructor(config: RedisConfig, logger: Logger) {
+    this.config = config;
+    this.logger = logger;
+
+    const clientOptions: RedisClientOptions = {
+      url: config.url, // url takes precedence
+      socket: config.url ? undefined : { host: config.host || 'localhost', port: config.port || 6379 },
+      password: config.password,
+    };
+
+    this.publisher = createClient(clientOptions);
+    this.subscriber = this.publisher.duplicate(); // Duplicate client for subscribing
+
+    this.publisher.on('error', (err) => this.logger.error({ err }, 'Redis Publisher Error'));
+    this.subscriber.on('error', (err) => this.logger.error({ err }, 'Redis Subscriber Error'));
+  }
+
+  async connect(): Promise<void> {
+    try {
+      await this.publisher.connect();
+      await this.subscriber.connect();
+      this.logger.info('Connected to Redis for Pub/Sub');
+    } catch (error) {
+      this.logger.error({ error }, 'Failed to connect to Redis');
+      throw error;
+    }
+  }
+
+  private getFullChannelName(channel: string): string {
+    return `${this.config.defaultChannelPrefix || ''}${channel}`;
+  }
+
+  async publish(channel: string, message: Message): Promise<void> {
+    if (!this.publisher.isOpen) {
+        this.logger.error('Redis publisher not connected. Cannot publish.');
+        throw new Error('Redis publisher not connected.');
+    }
+    const fullChannel = this.getFullChannelName(channel);
+    const messageString = typeof message === 'object' ? JSON.stringify(message) : String(message);
+    try {
+        await this.publisher.publish(fullChannel, messageString);
+        this.logger.debug({ channel: fullChannel }, 'Message published to Redis channel');
+    } catch (error) {
+        this.logger.error({ error, channel: fullChannel }, 'Error publishing message to Redis');
+        throw error;
+    }
+  }
+
+  async subscribe(channel: string, onMessageCallback: MessageHandler): Promise<string> {
+    if (!this.subscriber.isOpen) {
+        this.logger.error('Redis subscriber not connected. Cannot subscribe.');
+        throw new Error('Redis subscriber not connected.');
+    }
+    const fullChannel = this.getFullChannelName(channel);
+
+    if (!this.messageHandlers.has(fullChannel)) {
+      this.messageHandlers.set(fullChannel, []);
+    }
+    this.messageHandlers.get(fullChannel)?.push(onMessageCallback);
+    this.logger.info(`Handler added for Redis channel: ${fullChannel}. Total handlers: ${this.messageHandlers.get(fullChannel)?.length}`);
+
+    // Subscribe with Redis client only if it's the first handler for this channel
+    // and there's no active Redis subscription yet for this channel.
+    if (!this.activeRedisSubscriptions.has(fullChannel)) {
+      try {
+        await this.subscriber.subscribe(fullChannel, (message, subscribedChannel) => {
+          // Redis v4 message is always string. If it was JSON, it needs parsing.
+          let parsedMessage: Message;
+          try {
+            // Attempt to parse if it looks like JSON, otherwise pass as string
+            if (message.startsWith('{') && message.endsWith('}')) {
+                 parsedMessage = JSON.parse(message);
+            } else {
+                 parsedMessage = message;
+            }
+          } catch (e) {
+            parsedMessage = message; // If JSON.parse fails, treat as plain string
+            this.logger.debug({ channel: subscribedChannel, error: e }, 'Failed to parse incoming message as JSON, treating as string.');
+          }
+          
+          const handlers = this.messageHandlers.get(subscribedChannel);
+          if (handlers) {
+            this.logger.debug(`Delivering message from ${subscribedChannel} to ${handlers.length} handlers.`);
+            handlers.forEach(handler => {
+                try {
+                    handler(parsedMessage);
+                } catch (handlerError) {
+                    this.logger.error({ error: handlerError, channel: subscribedChannel }, 'Error in Redis message handler');
+                }
+            });
+          }
+        });
+        this.activeRedisSubscriptions.set(fullChannel, true);
+        this.logger.info(`Successfully subscribed to Redis channel: ${fullChannel}`);
+      } catch (error) {
+          this.logger.error({ error, channel: fullChannel }, 'Error subscribing to Redis channel');
+          // If subscription failed, remove the handler that was optimistically added.
+          const handlers = this.messageHandlers.get(fullChannel);
+          if (handlers) {
+            const index = handlers.indexOf(onMessageCallback);
+            if (index > -1) handlers.splice(index, 1);
+            if (handlers.length === 0) this.messageHandlers.delete(fullChannel);
+          }
+          throw error;
+      }
+    }
+    return fullChannel; // Use full channel name as subscriptionId for simplicity
+  }
+
+  async unsubscribe(channel: string, handlerToRemove?: MessageHandler): Promise<void> {
+    if (!this.subscriber.isOpen && !handlerToRemove) { // Allow removing handlers even if not connected
+        this.logger.warn('Redis subscriber not connected. Cannot unsubscribe from Redis channel itself, but will remove handlers.');
+    }
+    const fullChannel = this.getFullChannelName(channel);
+
+    const handlers = this.messageHandlers.get(fullChannel);
+    if (!handlers) {
+        this.logger.warn(`No handlers found for Redis channel: ${fullChannel} to unsubscribe.`);
+        return;
+    }
+
+    if (handlerToRemove) {
+      const index = handlers.indexOf(handlerToRemove);
+      if (index > -1) {
+        handlers.splice(index, 1);
+        this.logger.info(`Handler removed for Redis channel: ${fullChannel}`);
+      }
+      if (handlers.length === 0) {
+        this.messageHandlers.delete(fullChannel);
+      }
+    } else { // Unsubscribe all handlers for this channel for this instance
+      this.messageHandlers.delete(fullChannel);
+      this.logger.info(`All handlers removed for Redis channel: ${fullChannel}`);
+    }
+    
+    // If no more local handlers for this channel, and there was an active Redis subscription, unsubscribe from Redis
+    if (!this.messageHandlers.has(fullChannel) && this.activeRedisSubscriptions.has(fullChannel)) {
+      if (this.subscriber.isOpen) {
+        try {
+            await this.subscriber.unsubscribe(fullChannel);
+            this.logger.info(`Successfully unsubscribed from Redis channel: ${fullChannel}`);
+        } catch (error) {
+            this.logger.error({ error, channel: fullChannel }, 'Error unsubscribing from Redis channel');
+            // Even if unsubscribe fails, we mark it as inactive locally, as we have no more handlers.
+        }
+      } else {
+          this.logger.warn(`Redis subscriber not connected, cannot send UNSUBSCRIBE for ${fullChannel}. Marking as inactive.`);
+      }
+      this.activeRedisSubscriptions.delete(fullChannel);
+    }
+  }
+
+  async close(): Promise<void> {
+    try {
+      // Unsubscribe from all active Redis subscriptions first
+      if (this.subscriber.isOpen) {
+        const channelsToUnsubscribe = Array.from(this.activeRedisSubscriptions.keys());
+        if (channelsToUnsubscribe.length > 0) {
+            await this.subscriber.unsubscribe(channelsToUnsubscribe);
+            this.logger.info(`Unsubscribed from all active Redis channels: ${channelsToUnsubscribe.join(', ')}`);
+        }
+        await this.subscriber.quit();
+      }
+    } catch (error) {
+        this.logger.error({ error }, 'Error during Redis subscriber quit/unsubscribeAll.');
+    } finally {
+        this.activeRedisSubscriptions.clear();
+        this.messageHandlers.clear(); // Clear all local handlers
+    }
+
+    try {
+      if (this.publisher.isOpen) {
+        await this.publisher.quit();
+      }
+    } catch (error) {
+        this.logger.error({ error }, 'Error during Redis publisher quit.');
+    }
+    
+    this.logger.info('Redis Pub/Sub connections closed.');
+  }
+}

--- a/packages/plugin-messagebroker/test/MessageBrokerPlugin.test.ts
+++ b/packages/plugin-messagebroker/test/MessageBrokerPlugin.test.ts
@@ -1,0 +1,219 @@
+import { MessageBrokerPlugin, MessageBrokerPluginConfig, RabbitMQConfig, RedisConfig } from '../src';
+import { RabbitMQService } from '../src/rabbitmq.service';
+import { RedisPubSubService } from '../src/redis.service';
+import { Logger, Service, Message, MessageHandler } from '@arifwidianto/msa-core';
+
+// Mock Logger
+const mockLoggerInstance = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+};
+
+// Mock Service
+const mockServiceInstance = {
+  getLogger: jest.fn(() => mockLoggerInstance as unknown as Logger),
+  // Add other Service methods if your plugin uses them
+};
+
+// Mock RabbitMQService
+const mockRabbitMQServiceInstance = {
+  connect: jest.fn().mockResolvedValue(undefined),
+  publish: jest.fn().mockResolvedValue(undefined),
+  subscribe: jest.fn().mockResolvedValue('mock-consumer-tag'),
+  unsubscribe: jest.fn().mockResolvedValue(undefined),
+  close: jest.fn().mockResolvedValue(undefined),
+};
+jest.mock('../src/rabbitmq.service', () => ({
+  RabbitMQService: jest.fn(() => mockRabbitMQServiceInstance),
+}));
+
+// Mock RedisPubSubService
+const mockRedisPubSubServiceInstance = {
+  connect: jest.fn().mockResolvedValue(undefined),
+  publish: jest.fn().mockResolvedValue(undefined),
+  subscribe: jest.fn().mockResolvedValue('mock-redis-channel'),
+  unsubscribe: jest.fn().mockResolvedValue(undefined),
+  close: jest.fn().mockResolvedValue(undefined),
+};
+jest.mock('../src/redis.service', () => ({
+  RedisPubSubService: jest.fn(() => mockRedisPubSubServiceInstance),
+}));
+
+
+describe('MessageBrokerPlugin', () => {
+  let plugin: MessageBrokerPlugin;
+  const rabbitmqConfig: RabbitMQConfig = { url: 'amqp://test' };
+  const redisConfig: RedisConfig = { url: 'redis://test', defaultChannelPrefix: 'msa:' };
+  
+  const rabbitmqPluginConfig: MessageBrokerPluginConfig = {
+    clientType: 'rabbitmq',
+    rabbitmq: rabbitmqConfig,
+  };
+  const redisPluginConfig: MessageBrokerPluginConfig = {
+    clientType: 'redis',
+    redis: redisConfig,
+  };
+
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    plugin = new MessageBrokerPlugin();
+  });
+
+  describe('Initialization', () => {
+    it('should initialize RabbitMQService if clientType is rabbitmq', async () => {
+      await plugin.initialize(rabbitmqPluginConfig, mockServiceInstance as unknown as Service);
+      expect(mockServiceInstance.getLogger).toHaveBeenCalledWith(plugin.name);
+      expect(RabbitMQService).toHaveBeenCalledWith(rabbitmqConfig, mockLoggerInstance);
+      expect(plugin['rabbitmqService']).toBe(mockRabbitMQServiceInstance);
+      expect(plugin['redisService']).toBeUndefined();
+    });
+
+    it('should initialize RedisPubSubService if clientType is redis', async () => {
+      await plugin.initialize(redisPluginConfig, mockServiceInstance as unknown as Service);
+      expect(mockServiceInstance.getLogger).toHaveBeenCalledWith(plugin.name);
+      expect(RedisPubSubService).toHaveBeenCalledWith(redisConfig, mockLoggerInstance);
+      expect(plugin['redisService']).toBe(mockRedisPubSubServiceInstance);
+      expect(plugin['rabbitmqService']).toBeUndefined();
+    });
+
+    it('should warn if clientType is not configured or unknown', async () => {
+      const wrongConfig = { clientType: 'unknown' } as any;
+      await plugin.initialize(wrongConfig, mockServiceInstance as unknown as Service);
+      expect(mockLoggerInstance.warn).toHaveBeenCalledWith('Message broker clientType not configured properly or unknown.');
+    });
+  });
+
+  describe('Lifecycle Methods (start, stop) - RabbitMQ', () => {
+    beforeEach(async () => {
+      await plugin.initialize(rabbitmqPluginConfig, mockServiceInstance as unknown as Service);
+    });
+
+    it('start() should call connect on RabbitMQService', async () => {
+      await plugin.start();
+      expect(mockRabbitMQServiceInstance.connect).toHaveBeenCalled();
+    });
+
+    it('stop() should call close on RabbitMQService', async () => {
+      await plugin.stop();
+      expect(mockRabbitMQServiceInstance.close).toHaveBeenCalled();
+    });
+  });
+  
+  describe('Lifecycle Methods (start, stop) - Redis', () => {
+    let mockRedisServiceInstance: any; // To store the instance created by the mock
+
+    beforeEach(async () => {
+      // Setup RedisPubSubService mock for these tests
+      // This ensures that when RedisPubSubService is newed up by the plugin, our mock instance is used.
+      (RedisPubSubService as jest.Mock).mockImplementation(() => mockRedisPubSubServiceInstance);
+      
+      await plugin.initialize(redisPluginConfig, mockServiceInstance as unknown as Service);
+    });
+
+    it('start() should call connect on RedisPubSubService', async () => {
+      await plugin.start();
+      expect(mockRedisPubSubServiceInstance.connect).toHaveBeenCalled();
+    });
+
+    it('stop() should call close on RedisPubSubService', async () => {
+      await plugin.stop();
+      expect(mockRedisPubSubServiceInstance.close).toHaveBeenCalled();
+    });
+  });
+
+
+  describe('ITransport Implementation - RabbitMQ', () => {
+    const testQueue = 'test-q';
+    const testMessage: Message = 'hello there';
+    let handler: jest.Mock<MessageHandler>;
+
+    beforeEach(async () => {
+      await plugin.initialize(rabbitmqPluginConfig, mockServiceInstance as unknown as Service);
+      handler = jest.fn();
+    });
+
+    it('listen() should call RabbitMQService.subscribe', async () => {
+      await plugin.listen(testQueue, handler);
+      expect(mockRabbitMQServiceInstance.subscribe).toHaveBeenCalledWith(testQueue, handler);
+    });
+
+    it('send() should call RabbitMQService.publish', async () => {
+      await plugin.send(testMessage, 'rk', 'ex');
+      expect(mockRabbitMQServiceInstance.publish).toHaveBeenCalledWith('ex', 'rk', testMessage);
+    });
+    
+    it('close() without args should call RabbitMQService.close', async () => {
+        await plugin.close();
+        expect(mockRabbitMQServiceInstance.close).toHaveBeenCalled();
+    });
+
+    it('close() with subscriptionId should call RabbitMQService.unsubscribe', async () => {
+        const subId = 'sub-id-for-rabbitmq';
+        // @ts-ignore
+        plugin['transportSubscriptions'].set(subId, { type: 'rabbitmq', queueOrChannelName: testQueue, rabbitConsumerTag: 'tag1', specificHandler: handler });
+        await plugin.close(subId);
+        expect(mockRabbitMQServiceInstance.unsubscribe).toHaveBeenCalledWith(testQueue, handler, 'tag1');
+    });
+  });
+
+  describe('ITransport Implementation - Redis', () => {
+    const testChannel = 'test-chan';
+    const testMessage: Message = 'redis message';
+    let handler: jest.Mock<MessageHandler>;
+    let handler: jest.Mock<MessageHandler>;
+
+    beforeEach(async () => {
+      // Ensure RedisPubSubService is mocked for each test in this describe block if plugin is re-initialized
+      (RedisPubSubService as jest.Mock).mockImplementation(() => mockRedisPubSubServiceInstance);
+      await plugin.initialize(redisPluginConfig, mockServiceInstance as unknown as Service);
+      handler = jest.fn();
+    });
+
+    it('listen() should call RedisPubSubService.subscribe', async () => {
+      await plugin.listen(testChannel, handler);
+      expect(mockRedisPubSubServiceInstance.subscribe).toHaveBeenCalledWith(testChannel, handler);
+    });
+
+    it('send() should call RedisPubSubService.publish', async () => {
+      await plugin.send(testMessage, testChannel); // For Redis, topicOrRoutingKey is the channel
+      expect(mockRedisPubSubServiceInstance.publish).toHaveBeenCalledWith(testChannel, testMessage);
+    });
+    
+    it('send() should throw error if topicOrRoutingKey (channel) is missing for Redis', async () => {
+        await expect(plugin.send(testMessage)).rejects.toThrow('Redis publish requires a channel name.');
+    });
+    
+    it('close() without args should call RedisPubSubService.close', async () => {
+        await plugin.close();
+        expect(mockRedisPubSubServiceInstance.close).toHaveBeenCalled();
+    });
+
+    it('close() with subscriptionId should call RedisPubSubService.unsubscribe', async () => {
+        const subId = 'sub-id-for-redis';
+        // @ts-ignore
+        plugin['transportSubscriptions'].set(subId, { type: 'redis', queueOrChannelName: testChannel, specificHandler: handler });
+        await plugin.close(subId);
+        expect(mockRedisPubSubServiceInstance.unsubscribe).toHaveBeenCalledWith(testChannel, handler);
+    });
+  });
+  
+  describe('Cleanup', () => {
+    it('should close and undefine RabbitMQService', async () => {
+        await plugin.initialize(rabbitmqPluginConfig, mockServiceInstance as unknown as Service);
+        await plugin.cleanup();
+        expect(mockRabbitMQServiceInstance.close).toHaveBeenCalled();
+        expect(plugin['rabbitmqService']).toBeUndefined();
+    });
+    
+    it('should close and undefine RedisPubSubService', async () => {
+        (RedisPubSubService as jest.Mock).mockImplementation(() => mockRedisPubSubServiceInstance);
+        await plugin.initialize(redisPluginConfig, mockServiceInstance as unknown as Service);
+        await plugin.cleanup();
+        expect(mockRedisPubSubServiceInstance.close).toHaveBeenCalled();
+        expect(plugin['redisService']).toBeUndefined();
+    });
+  });
+});

--- a/packages/plugin-messagebroker/test/MessageBrokerPlugin.test.ts
+++ b/packages/plugin-messagebroker/test/MessageBrokerPlugin.test.ts
@@ -13,7 +13,7 @@ const mockLoggerInstance = {
 
 // Mock Service
 const mockServiceInstance = {
-  getLogger: jest.fn(() => mockLoggerInstance as unknown as Logger),
+  getLogger: jest.fn(() => mockLoggerInstance as unknown as typeof Logger),
   // Add other Service methods if your plugin uses them
 };
 
@@ -135,8 +135,10 @@ describe('MessageBrokerPlugin', () => {
       handler = jest.fn();
     });
 
-    it('listen() should call RabbitMQService.subscribe', async () => {
-      await plugin.listen(testQueue, handler);
+    it('listen() should set up default queue/topic', async () => {
+      await plugin.listen(testQueue);
+      // Now call subscribeToTopic separately with the handler
+      await plugin.subscribeToTopic(testQueue, handler);
       expect(mockRabbitMQServiceInstance.subscribe).toHaveBeenCalledWith(testQueue, handler);
     });
 
@@ -163,7 +165,6 @@ describe('MessageBrokerPlugin', () => {
     const testChannel = 'test-chan';
     const testMessage: Message = 'redis message';
     let handler: jest.Mock<MessageHandler>;
-    let handler: jest.Mock<MessageHandler>;
 
     beforeEach(async () => {
       // Ensure RedisPubSubService is mocked for each test in this describe block if plugin is re-initialized
@@ -173,7 +174,7 @@ describe('MessageBrokerPlugin', () => {
     });
 
     it('listen() should call RedisPubSubService.subscribe', async () => {
-      await plugin.listen(testChannel, handler);
+      await plugin.listen(testChannel);
       expect(mockRedisPubSubServiceInstance.subscribe).toHaveBeenCalledWith(testChannel, handler);
     });
 

--- a/packages/plugin-messagebroker/test/RabbitMQService.test.ts
+++ b/packages/plugin-messagebroker/test/RabbitMQService.test.ts
@@ -1,0 +1,200 @@
+import { RabbitMQService } from '../src/rabbitmq.service';
+import { RabbitMQConfig } from '../src/MessageBrokerPluginConfig';
+import { Logger, MessageHandler } from '@arifwidianto/msa-core';
+import amqp from 'amqplib';
+
+// Mock Logger from @arifwidianto/msa-core
+const mockLoggerInstance = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+};
+const MockLogger = mockLoggerInstance as unknown as Logger;
+
+// Mock amqplib
+const mockChannel = {
+  assertExchange: jest.fn().mockResolvedValue(undefined),
+  assertQueue: jest.fn().mockResolvedValue(undefined),
+  bindQueue: jest.fn().mockResolvedValue(undefined),
+  publish: jest.fn().mockReturnValue(true), // Simulate successful publish
+  consume: jest.fn().mockResolvedValue({ consumerTag: 'test-consumer-tag' }),
+  ack: jest.fn(),
+  cancel: jest.fn().mockResolvedValue(undefined),
+  close: jest.fn().mockResolvedValue(undefined),
+  on: jest.fn(), // For 'error' and 'close' events on channel
+};
+const mockConnection = {
+  createChannel: jest.fn().mockResolvedValue(mockChannel),
+  close: jest.fn().mockResolvedValue(undefined),
+  on: jest.fn(), // For 'error' and 'close' events on connection
+};
+jest.mock('amqplib', () => ({
+  connect: jest.fn().mockResolvedValue(mockConnection),
+}));
+
+describe('RabbitMQService', () => {
+  let service: RabbitMQService;
+  const config: RabbitMQConfig = {
+    url: 'amqp://localhost',
+    defaultExchange: { name: 'test-exchange', type: 'direct' },
+    defaultQueue: { name: 'test-queue' },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new RabbitMQService(config, MockLogger);
+  });
+
+  describe('connect', () => {
+    it('should connect to RabbitMQ, create channel, and assert defaults', async () => {
+      await service.connect();
+      expect(amqp.connect).toHaveBeenCalledWith(config.url);
+      expect(mockConnection.createChannel).toHaveBeenCalled();
+      expect(mockChannel.assertExchange).toHaveBeenCalledWith(config.defaultExchange!.name, config.defaultExchange!.type, { durable: true });
+      expect(mockChannel.assertQueue).toHaveBeenCalledWith(config.defaultQueue!.name, { durable: true });
+      expect(mockChannel.bindQueue).toHaveBeenCalledWith(config.defaultQueue!.name, config.defaultExchange!.name, '');
+      expect(MockLogger.info).toHaveBeenCalledWith('Successfully connected to RabbitMQ server.');
+      expect(MockLogger.info).toHaveBeenCalledWith('RabbitMQ channel created.');
+    });
+
+    it('should handle connection error', async () => {
+      const error = new Error('Connection failed');
+      (amqp.connect as jest.Mock).mockRejectedValueOnce(error);
+      await expect(service.connect()).rejects.toThrow(error);
+      expect(MockLogger.error).toHaveBeenCalledWith({ error }, 'Failed to connect to RabbitMQ or setup defaults');
+    });
+    
+    it('should register event listeners for connection and channel', async () => {
+        await service.connect();
+        expect(mockConnection.on).toHaveBeenCalledWith('error', expect.any(Function));
+        expect(mockConnection.on).toHaveBeenCalledWith('close', expect.any(Function));
+        expect(mockChannel.on).toHaveBeenCalledWith('error', expect.any(Function));
+        expect(mockChannel.on).toHaveBeenCalledWith('close', expect.any(Function));
+    });
+  });
+
+  describe('publish', () => {
+    beforeEach(async () => {
+      await service.connect(); // Ensure channel is available
+    });
+
+    it('should publish a message', async () => {
+      const content = { data: 'test message' };
+      await service.publish('test-exchange', 'test-key', content);
+      expect(mockChannel.publish).toHaveBeenCalledWith(
+        'test-exchange',
+        'test-key',
+        Buffer.from(JSON.stringify(content)),
+        undefined // options
+      );
+      expect(MockLogger.debug).toHaveBeenCalledWith({ exchange: 'test-exchange', routingKey: 'test-key', options: undefined }, 'Message published to RabbitMQ.');
+    });
+
+    it('should throw error if channel is not available', async () => {
+      await service.close(); // Close connection and channel
+      await expect(service.publish('ex', 'rk', 'msg')).rejects.toThrow('RabbitMQ channel not available.');
+    });
+    
+    it('should warn if publish buffer is full', async () => {
+        (mockChannel.publish as jest.Mock).mockReturnValueOnce(false); // Simulate buffer full
+        await service.publish('ex', 'rk', 'msg');
+        expect(MockLogger.warn).toHaveBeenCalledWith({ exchange: 'ex', routingKey: 'rk', options: undefined }, 'RabbitMQ publish buffer is full. Message was not published.');
+    });
+  });
+
+  describe('subscribe and unsubscribe', () => {
+    let handler: jest.Mock<MessageHandler>;
+    const queueName = 'my-queue';
+
+    beforeEach(async () => {
+      await service.connect();
+      handler = jest.fn();
+    });
+
+    it('should subscribe to a queue and process messages', async () => {
+      const consumerTag = await service.subscribe(queueName, handler);
+      expect(consumerTag).toBe('test-consumer-tag');
+      expect(mockChannel.assertQueue).toHaveBeenCalledWith(queueName, { durable: true });
+      expect(mockChannel.consume).toHaveBeenCalledWith(queueName, expect.any(Function), { noAck: false });
+      expect(MockLogger.info).toHaveBeenCalledWith(`Subscribed to RabbitMQ queue: ${queueName} with consumerTag: ${consumerTag}`);
+
+      // Simulate receiving a message
+      const consumeCallback = (mockChannel.consume as jest.Mock).mock.calls[0][1];
+      const testMessage = { content: Buffer.from('hello world'), properties: { messageId: "msg123"} };
+      consumeCallback(testMessage);
+
+      expect(handler).toHaveBeenCalledWith('hello world');
+      expect(mockChannel.ack).toHaveBeenCalledWith(testMessage);
+    });
+
+    it('should add multiple handlers to the same queue and use existing consumer', async () => {
+        const handler1 = jest.fn();
+        const handler2 = jest.fn();
+
+        const consumerTag1 = await service.subscribe(queueName, handler1);
+        expect(consumerTag1).toBe('test-consumer-tag'); // First handler creates consumer
+
+        const consumerTag2 = await service.subscribe(queueName, handler2);
+        expect(consumerTag2).toBe('test-consumer-tag'); // Second handler uses existing consumer for the queue
+
+        expect(mockChannel.consume).toHaveBeenCalledTimes(1); // consume only called once for the queue
+        expect(MockLogger.info).toHaveBeenCalledWith(`Added new handler to existing subscription on queue: ${queueName}`);
+
+        // Simulate message, both handlers should be called
+        const consumeCallback = (mockChannel.consume as jest.Mock).mock.calls[0][1];
+        const testMessage = { content: Buffer.from('shared message'), properties: { messageId: "msgShared"} };
+        consumeCallback(testMessage);
+        expect(handler1).toHaveBeenCalledWith('shared message');
+        expect(handler2).toHaveBeenCalledWith('shared message');
+        expect(mockChannel.ack).toHaveBeenCalledWith(testMessage);
+    });
+
+    it('should unsubscribe a specific handler and then the consumer if no handlers left', async () => {
+        const handler1 = jest.fn();
+        const handler2 = jest.fn();
+        const consumerTag = await service.subscribe(queueName, handler1);
+        await service.subscribe(queueName, handler2); // Adds handler2
+
+        // Unsubscribe handler1
+        await service.unsubscribe(queueName, handler1, consumerTag!);
+        expect(MockLogger.info).toHaveBeenCalledWith(`Handler removed for queue: ${queueName}`);
+        // @ts-ignore
+        expect(service['messageHandlers'].get(queueName)?.handlers.includes(handler1)).toBe(false);
+        // @ts-ignore
+        expect(service['messageHandlers'].get(queueName)?.handlers.includes(handler2)).toBe(true);
+        expect(mockChannel.cancel).not.toHaveBeenCalled(); // Consumer still active for handler2
+
+        // Unsubscribe handler2 (last one for this consumerTag)
+        await service.unsubscribe(queueName, handler2, consumerTag!);
+        expect(MockLogger.info).toHaveBeenCalledWith(`Handler removed for queue: ${queueName}`); // Handler removed log
+        expect(mockChannel.cancel).toHaveBeenCalledWith(consumerTag);
+        expect(MockLogger.info).toHaveBeenCalledWith(`Consumer (tag: ${consumerTag}) cancelled for RabbitMQ queue: ${queueName}`);
+        // @ts-ignore
+        expect(service['messageHandlers'].has(queueName)).toBe(false);
+    });
+
+    it('should throw error if channel not available on subscribe', async () => {
+      await service.close();
+      await expect(service.subscribe(queueName, handler)).rejects.toThrow('RabbitMQ channel not available.');
+    });
+  });
+
+  describe('close', () => {
+    it('should close channel and connection, and cancel consumers', async () => {
+      await service.connect();
+      // Simulate an active subscription to test consumer cancellation
+      const handler = jest.fn();
+      const queueName = 'another-queue';
+      const consumerTag = await service.subscribe(queueName, handler);
+
+      await service.close();
+
+      expect(mockChannel.cancel).toHaveBeenCalledWith(consumerTag); // Ensure consumer is cancelled
+      expect(mockChannel.close).toHaveBeenCalled();
+      expect(mockConnection.close).toHaveBeenCalled();
+      expect(MockLogger.info).toHaveBeenCalledWith('RabbitMQ channel closed.');
+      expect(MockLogger.info).toHaveBeenCalledWith('RabbitMQ connection closed.');
+    });
+  });
+});

--- a/packages/plugin-messagebroker/test/RabbitMQService.test.ts
+++ b/packages/plugin-messagebroker/test/RabbitMQService.test.ts
@@ -10,7 +10,7 @@ const mockLoggerInstance = {
   error: jest.fn(),
   debug: jest.fn(),
 };
-const MockLogger = mockLoggerInstance as unknown as Logger;
+const MockLogger = mockLoggerInstance as unknown as typeof Logger;
 
 // Mock amqplib
 const mockChannel = {

--- a/packages/plugin-messagebroker/test/redis.service.test.ts
+++ b/packages/plugin-messagebroker/test/redis.service.test.ts
@@ -10,7 +10,7 @@ const mockLoggerInstance = {
   error: jest.fn(),
   debug: jest.fn(),
 };
-const MockLogger = mockLoggerInstance as unknown as Logger;
+const MockLogger = mockLoggerInstance as unknown as typeof Logger;
 
 // Mock 'redis' client
 const mockRedisClientInstance = {

--- a/packages/plugin-messagebroker/test/redis.service.test.ts
+++ b/packages/plugin-messagebroker/test/redis.service.test.ts
@@ -1,0 +1,208 @@
+import { RedisPubSubService } from '../src/redis.service';
+import { RedisConfig } from '../src/MessageBrokerPluginConfig';
+import { Logger, MessageHandler } from '@arifwidianto/msa-core';
+import { createClient, RedisClientType } from 'redis';
+
+// Mock Logger from @arifwidianto/msa-core
+const mockLoggerInstance = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+};
+const MockLogger = mockLoggerInstance as unknown as Logger;
+
+// Mock 'redis' client
+const mockRedisClientInstance = {
+  connect: jest.fn().mockResolvedValue(undefined),
+  publish: jest.fn().mockResolvedValue(0), // 0 is a valid return for publish (number of clients received)
+  subscribe: jest.fn().mockResolvedValue(undefined),
+  unsubscribe: jest.fn().mockResolvedValue(undefined),
+  quit: jest.fn().mockResolvedValue(undefined),
+  on: jest.fn(),
+  isOpen: true, // Simulate connected state by default after connect()
+  duplicate: jest.fn(), // Important for publisher/subscriber separation
+};
+// Ensure duplicate returns a new mock instance for the subscriber
+const mockSubscriberInstance = { ...mockRedisClientInstance, duplicate: jest.fn() }; // Subscriber shouldn't duplicate again
+mockRedisClientInstance.duplicate.mockReturnValue(mockSubscriberInstance as unknown as RedisClientType);
+
+
+jest.mock('redis', () => ({
+  createClient: jest.fn(() => mockRedisClientInstance as unknown as RedisClientType),
+}));
+
+describe('RedisPubSubService', () => {
+  let service: RedisPubSubService;
+  const config: RedisConfig = {
+    url: 'redis://localhost:6379',
+    defaultChannelPrefix: 'msa-test:',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Reset isOpen state for mocks before each test, assuming connect will set it
+    mockRedisClientInstance.isOpen = false;
+    mockSubscriberInstance.isOpen = false;
+    service = new RedisPubSubService(config, MockLogger);
+  });
+
+  describe('connect', () => {
+    it('should connect both publisher and subscriber clients', async () => {
+      // Simulate connect() making them "open"
+      (mockRedisClientInstance.connect as jest.Mock).mockImplementationOnce(async () => { mockRedisClientInstance.isOpen = true; });
+      (mockSubscriberInstance.connect as jest.Mock).mockImplementationOnce(async () => { mockSubscriberInstance.isOpen = true; });
+
+      await service.connect();
+      expect(createClient).toHaveBeenCalledTimes(1); // Called once, then duplicated
+      expect(mockRedisClientInstance.duplicate).toHaveBeenCalledTimes(1);
+      expect(mockRedisClientInstance.connect).toHaveBeenCalled();
+      expect(mockSubscriberInstance.connect).toHaveBeenCalled();
+      expect(MockLogger.info).toHaveBeenCalledWith('Connected to Redis for Pub/Sub');
+    });
+
+    it('should handle connection error', async () => {
+      const error = new Error('Redis connection failed');
+      (mockRedisClientInstance.connect as jest.Mock).mockRejectedValueOnce(error);
+      await expect(service.connect()).rejects.toThrow(error);
+      expect(MockLogger.error).toHaveBeenCalledWith({ error }, 'Failed to connect to Redis');
+    });
+    
+    it('should register error listeners for publisher and subscriber', () => {
+        // Constructor is called in beforeEach
+        expect(mockRedisClientInstance.on).toHaveBeenCalledWith('error', expect.any(Function));
+        expect(mockSubscriberInstance.on).toHaveBeenCalledWith('error', expect.any(Function));
+    });
+  });
+
+  describe('publish', () => {
+    beforeEach(async () => {
+      // Simulate successful connection
+      (mockRedisClientInstance.connect as jest.Mock).mockImplementationOnce(async () => { mockRedisClientInstance.isOpen = true; });
+      (mockSubscriberInstance.connect as jest.Mock).mockImplementationOnce(async () => { mockSubscriberInstance.isOpen = true; });
+      await service.connect();
+    });
+
+    it('should publish a message to the correct channel with prefix', async () => {
+      const channel = 'test-channel';
+      const message = { data: 'hello' };
+      await service.publish(channel, message);
+      const fullChannel = `${config.defaultChannelPrefix}${channel}`;
+      expect(mockRedisClientInstance.publish).toHaveBeenCalledWith(fullChannel, JSON.stringify(message));
+      expect(MockLogger.debug).toHaveBeenCalledWith({ channel: fullChannel }, 'Message published to Redis channel');
+    });
+
+    it('should throw error if publisher is not connected', async () => {
+      mockRedisClientInstance.isOpen = false; // Simulate not connected
+      await expect(service.publish('ch', 'msg')).rejects.toThrow('Redis publisher not connected.');
+    });
+  });
+
+  describe('subscribe and unsubscribe', () => {
+    let handler: jest.Mock<MessageHandler>;
+    const channel = 'notifications';
+    const fullChannel = `${config.defaultChannelPrefix}${channel}`;
+
+    beforeEach(async () => {
+      (mockRedisClientInstance.connect as jest.Mock).mockImplementationOnce(async () => { mockRedisClientInstance.isOpen = true; });
+      (mockSubscriberInstance.connect as jest.Mock).mockImplementationOnce(async () => { mockSubscriberInstance.isOpen = true; });
+      await service.connect();
+      handler = jest.fn();
+    });
+
+    it('should subscribe to a channel and call Redis client subscribe if first handler', async () => {
+      await service.subscribe(channel, handler);
+      expect(mockSubscriberInstance.subscribe).toHaveBeenCalledWith(fullChannel, expect.any(Function));
+      expect(MockLogger.info).toHaveBeenCalledWith(`Successfully subscribed to Redis channel: ${fullChannel}`);
+      // @ts-ignore
+      expect(service['messageHandlers'].get(fullChannel)).toContain(handler);
+      // @ts-ignore
+      expect(service['activeRedisSubscriptions'].has(fullChannel)).toBe(true);
+    });
+
+    it('should add handler without calling Redis client subscribe if already subscribed to channel', async () => {
+      const handler2 = jest.fn();
+      await service.subscribe(channel, handler); // First subscription
+      await service.subscribe(channel, handler2); // Second subscription to same channel
+
+      expect(mockSubscriberInstance.subscribe).toHaveBeenCalledTimes(1); // Only called once
+      expect(MockLogger.info).toHaveBeenCalledWith(`Handler added for Redis channel: ${fullChannel}. Total handlers: 2`);
+      // @ts-ignore
+      expect(service['messageHandlers'].get(fullChannel)).toEqual([handler, handler2]);
+    });
+
+    it('should process incoming messages and call appropriate handlers', async () => {
+      await service.subscribe(channel, handler);
+      const handler2 = jest.fn();
+      await service.subscribe(channel, handler2);
+
+      // Simulate receiving a message from Redis
+      const subscribeCallback = (mockSubscriberInstance.subscribe as jest.Mock).mock.calls[0][1];
+      const testMessage = { content: 'event happened' };
+      subscribeCallback(JSON.stringify(testMessage), fullChannel); // Redis sends message and channel
+
+      expect(handler).toHaveBeenCalledWith(testMessage);
+      expect(handler2).toHaveBeenCalledWith(testMessage);
+    });
+
+    it('should unsubscribe a specific handler and call Redis client unsubscribe if last handler', async () => {
+      await service.subscribe(channel, handler);
+      const handler2 = jest.fn();
+      await service.subscribe(channel, handler2);
+
+      await service.unsubscribe(channel, handler);
+      // @ts-ignore
+      expect(service['messageHandlers'].get(fullChannel)).toEqual([handler2]); // handler1 removed
+      expect(mockSubscriberInstance.unsubscribe).not.toHaveBeenCalled(); // Still has handler2
+
+      await service.unsubscribe(channel, handler2); // Remove last handler
+      // @ts-ignore
+      expect(service['messageHandlers'].has(fullChannel)).toBe(false);
+      expect(mockSubscriberInstance.unsubscribe).toHaveBeenCalledWith(fullChannel);
+      // @ts-ignore
+      expect(service['activeRedisSubscriptions'].has(fullChannel)).toBe(false);
+      expect(MockLogger.info).toHaveBeenCalledWith(`Successfully unsubscribed from Redis channel: ${fullChannel}`);
+    });
+    
+    it('should unsubscribe all handlers for a channel if no specific handler is given', async () => {
+        await service.subscribe(channel, handler);
+        await service.subscribe(channel, jest.fn()); // Add another handler
+
+        await service.unsubscribe(channel); // No specific handler
+        // @ts-ignore
+        expect(service['messageHandlers'].has(fullChannel)).toBe(false);
+        expect(mockSubscriberInstance.unsubscribe).toHaveBeenCalledWith(fullChannel);
+        // @ts-ignore
+        expect(service['activeRedisSubscriptions'].has(fullChannel)).toBe(false);
+    });
+
+    it('should throw error if subscriber is not connected on subscribe', async () => {
+      mockSubscriberInstance.isOpen = false;
+      await expect(service.subscribe(channel, handler)).rejects.toThrow('Redis subscriber not connected.');
+    });
+  });
+
+  describe('close', () => {
+    it('should quit publisher and subscriber, and unsubscribe from all channels', async () => {
+      // Simulate connected state and an active subscription
+      (mockRedisClientInstance.connect as jest.Mock).mockImplementationOnce(async () => { mockRedisClientInstance.isOpen = true; });
+      (mockSubscriberInstance.connect as jest.Mock).mockImplementationOnce(async () => { mockSubscriberInstance.isOpen = true; });
+      await service.connect();
+      const handler = jest.fn();
+      const channel1 = "channel1";
+      await service.subscribe(channel1, handler);
+      const fullChannel1 = `${config.defaultChannelPrefix}${channel1}`;
+
+      await service.close();
+
+      expect(mockSubscriberInstance.unsubscribe).toHaveBeenCalledWith([fullChannel1]); // Unsubscribe from active channels
+      expect(mockSubscriberInstance.quit).toHaveBeenCalled();
+      expect(mockRedisClientInstance.quit).toHaveBeenCalled();
+      expect(MockLogger.info).toHaveBeenCalledWith('Redis Pub/Sub connections closed.');
+      // @ts-ignore
+      expect(service['activeRedisSubscriptions'].size).toBe(0);
+      // @ts-ignore
+      expect(service['messageHandlers'].size).toBe(0);
+    });
+  });
+});

--- a/packages/plugin-messagebroker/tsconfig.build.json
+++ b/packages/plugin-messagebroker/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
+  "exclude": ["node_modules", "dist", "test"]
+}

--- a/packages/plugin-messagebroker/tsconfig.json
+++ b/packages/plugin-messagebroker/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["src"]
+}

--- a/packages/plugin-messagebroker/tsconfig.json
+++ b/packages/plugin-messagebroker/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "outDir": "./dist"
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }

--- a/packages/plugin-stdio/README.md
+++ b/packages/plugin-stdio/README.md
@@ -6,18 +6,13 @@ This plugin adds command-line interface (CLI) capabilities and standard I/O hand
 
 * Command-line argument parsing with Yargs
 * Interactive prompts and questions with Inquirer
-* Command registration with argument validation
+* Dynamic registration of CLI commands with argument validation
 * Interactive shell mode with command history
 * Standard output/error stream management
+* Line-by-line input listening in interactive mode
 * Full console logging capabilities
 * Support for both one-off commands and interactive sessions
-
-*   Parses command-line arguments using `yargs`.
-*   Supports interactive prompts using `inquirer`.
-*   Allows dynamic registration of CLI commands and their handlers.
-*   Can output messages to the console.
-*   Can listen for line-by-line input in an interactive mode.
-*   Implements `IPlugin` and conceptually `ITransport` from `@arifwidianto/msa-core`.
+* Implementation of both `IPlugin` and `ITransport` interfaces from `@arifwidianto/msa-core`
 
 ## Installation
 

--- a/packages/plugin-stdio/jest.config.js
+++ b/packages/plugin-stdio/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  displayName: 'plugin-stdio',
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/test/**/*.test.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.json'
+    }
+  },
+  moduleNameMapper: {
+    '^@arifwidianto/msa-core$': '<rootDir>/../core/src/index.ts'
+  }
+};

--- a/packages/plugin-stdio/package.json
+++ b/packages/plugin-stdio/package.json
@@ -3,13 +3,27 @@
   "version": "0.1.0",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc -p tsconfig.build.json"
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rimraf dist",
+    "dev": "tsc -p tsconfig.build.json --watch",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage",
+    "lint": "eslint src/**/*.ts",
+    "prepublishOnly": "npm run build"
   },
   "devDependencies": {
     "typescript": "^5.4.5",
     "@arifwidianto/msa-core": "0.1.0",
     "@types/yargs": "^17.0.32",
-    "@types/inquirer": "^9.0.7"
+    "@types/inquirer": "^9.0.7",
+    "rimraf": "^5.0.5",
+    "jest": "^29.7.0",
+    "@types/jest": "^29.5.12",
+    "eslint": "^8.52.0",
+    "@typescript-eslint/eslint-plugin": "^6.9.1",
+    "@typescript-eslint/parser": "^6.9.1",
+    "ts-jest": "^29.1.2"
   },
   "peerDependencies": {
     "@arifwidianto/msa-core": "0.1.0"

--- a/packages/plugin-stdio/src/StdioPlugin.ts
+++ b/packages/plugin-stdio/src/StdioPlugin.ts
@@ -52,7 +52,7 @@ export class StdioPlugin implements IPlugin, ITransport {
     this.commandHandlers.forEach((handler, commandKey) => {
         // Assuming commandKey is "command" or "command sub"
         const [cmd, ...subcommands] = commandKey.split(' ');
-        const commandModule: CommandModule = {
+        const commandModule: CommandModule<{}, {}> = {
             command: commandKey, // Full command string
             aliases: [], // Can be configured via addCommandHandler
             describe: `Handler for ${commandKey}`, // Can be configured
@@ -152,7 +152,7 @@ export class StdioPlugin implements IPlugin, ITransport {
       return;
     }
 
-    const commandModule: CommandModule<T, T> = {
+    const commandModule: CommandModule<{}, T> = {
       command,
       describe: description,
       builder: builder as any, // Type assertion needed due to complex yargs types
@@ -168,7 +168,7 @@ export class StdioPlugin implements IPlugin, ITransport {
           }
         }
         // Execute the specific handler for this command
-        handler(args);
+        handler(args as ArgumentsCamelCase<T>);
       },
     };
 

--- a/packages/plugin-stdio/test/StdioPlugin.test.ts
+++ b/packages/plugin-stdio/test/StdioPlugin.test.ts
@@ -1,0 +1,258 @@
+import { StdioPlugin, StdioPluginConfig } from '../src';
+import { Logger, MessageHandler } from '@arifwidianto/msa-core';
+import yargs, { ArgumentsCamelCase, Argv } from 'yargs';
+import inquirer from 'inquirer';
+import readline from 'readline';
+
+// Mock Logger from @arifwidianto/msa-core
+jest.mock('@arifwidianto/msa-core', () => {
+  const originalModule = jest.requireActual('@arifwidianto/msa-core');
+  return {
+    ...originalModule,
+    Logger: {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    },
+  };
+});
+
+// Mock yargs
+const mockYargsInstance = {
+  command: jest.fn().mockReturnThis(),
+  scriptName: jest.fn().mockReturnThis(),
+  usage: jest.fn().mockReturnThis(),
+  help: jest.fn().mockReturnThis(),
+  alias: jest.fn().mockReturnThis(),
+  demandCommand: jest.fn().mockReturnThis(),
+  strict: jest.fn().mockReturnThis(),
+  fail: jest.fn().mockReturnThis(),
+  parseAsync: jest.fn().mockResolvedValue({ _: [], $0: '' }), // Default mock for parseAsync
+  showHelp: jest.fn(),
+};
+jest.mock('yargs', () => jest.fn(() => mockYargsInstance));
+jest.mock('yargs/helpers', () => ({ hideBin: jest.fn((x) => x) }));
+
+
+// Mock inquirer
+jest.mock('inquirer', () => ({
+  prompt: jest.fn(),
+}));
+
+// Mock readline
+const mockReadlineInterface = {
+  prompt: jest.fn(),
+  on: jest.fn(),
+  close: jest.fn(),
+};
+jest.mock('readline', () => ({
+  createInterface: jest.fn(() => mockReadlineInterface),
+}));
+
+
+describe('StdioPlugin', () => {
+  let plugin: StdioPlugin;
+  const defaultConfig: StdioPluginConfig = { interactive: false };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    plugin = new StdioPlugin();
+  });
+
+  describe('Initialization', () => {
+    it('should initialize with default config', async () => {
+      await plugin.initialize({});
+      expect(Logger.info).toHaveBeenCalledWith(expect.stringContaining('initialized with config: {}'));
+      expect(yargs).toHaveBeenCalled();
+      expect(mockYargsInstance.scriptName).toHaveBeenCalled();
+    });
+
+    it('should initialize with provided config', async () => {
+      await plugin.initialize(defaultConfig);
+      expect(Logger.info).toHaveBeenCalledWith(expect.stringContaining(JSON.stringify(defaultConfig)));
+    });
+  });
+
+  describe('Command Handling', () => {
+    beforeEach(async () => {
+      await plugin.initialize(defaultConfig);
+    });
+
+    it('should add a command handler and register it with yargs', () => {
+      const handler = jest.fn();
+      const builder = { testOption: { type: 'string' } };
+      plugin.addCommandHandler('testCmd <arg>', 'A test command', builder as any, handler);
+      
+      expect(mockYargsInstance.command).toHaveBeenCalledWith(expect.objectContaining({
+        command: 'testCmd <arg>',
+        describe: 'A test command',
+        builder: builder,
+        // handler: expect.any(Function) // The actual handler is wrapped
+      }));
+      expect(Logger.info).toHaveBeenCalledWith('StdIO Plugin: Command handler added for "testCmd <arg>"');
+    });
+
+    it('command handler should call specific handler and global message handler if registered', async () => {
+        const specificHandler = jest.fn();
+        const globalMessageHandler = jest.fn();
+        plugin.onMessage(globalMessageHandler);
+
+        plugin.addCommandHandler('cmd', 'desc', {}, specificHandler);
+
+        // Simulate yargs calling the handler
+        const yargsRegisteredHandler = mockYargsInstance.command.mock.calls[0][0].handler;
+        const mockArgs = { _: ['cmd'], $0: 'test', arg1: 'val1' } as ArgumentsCamelCase<{arg1: string}>;
+        
+        await yargsRegisteredHandler(mockArgs);
+
+        expect(specificHandler).toHaveBeenCalledWith(mockArgs);
+        expect(globalMessageHandler).toHaveBeenCalledWith(expect.objectContaining({
+            type: 'command',
+            command: 'cmd',
+            arguments: mockArgs
+        }));
+    });
+  });
+
+  describe('Start Method', () => {
+    beforeEach(async () => {
+      await plugin.initialize({ interactive: true }); // Enable interactive for some tests
+    });
+
+    it('should parse argv using yargs', async () => {
+      await plugin.start();
+      expect(mockYargsInstance.parseAsync).toHaveBeenCalled();
+    });
+
+    it('should start interactive input if no command and interactive is true', async () => {
+      (mockYargsInstance.parseAsync as jest.Mock).mockResolvedValueOnce({ _: [], $0: '' }); // Simulate no command
+      const startInteractiveSpy = jest.spyOn(plugin, 'startInteractiveInput');
+      await plugin.start();
+      expect(startInteractiveSpy).toHaveBeenCalled();
+    });
+    
+    it('should show help if no command and interactive is false', async () => {
+        const nonInteractivePlugin = new StdioPlugin();
+        await nonInteractivePlugin.initialize({ interactive: false });
+        (mockYargsInstance.parseAsync as jest.Mock).mockResolvedValueOnce({ _: [], $0: '' });
+        await nonInteractivePlugin.start();
+        expect(mockYargsInstance.showHelp).toHaveBeenCalled();
+    });
+  });
+  
+  describe('Interactive Input', () => {
+    beforeEach(async () => {
+      await plugin.initialize({ promptPrefix: 'test> ' });
+    });
+
+    it('startInteractiveInput should setup readline and prompt', () => {
+      plugin.startInteractiveInput();
+      expect(readline.createInterface).toHaveBeenCalledWith({
+        input: process.stdin,
+        output: process.stdout,
+        prompt: 'test> '
+      });
+      expect(mockReadlineInterface.prompt).toHaveBeenCalled();
+      expect(mockReadlineInterface.on).toHaveBeenCalledWith('line', expect.any(Function));
+      expect(mockReadlineInterface.on).toHaveBeenCalledWith('close', expect.any(Function));
+    });
+
+    it('should handle "exit" command in interactive mode', async () => {
+      plugin.startInteractiveInput();
+      const lineHandler = mockReadlineInterface.on.mock.calls.find(call => call[0] === 'line')[1];
+      const stopSpy = jest.spyOn(plugin, 'stop');
+      await lineHandler('exit');
+      expect(stopSpy).toHaveBeenCalled();
+    });
+    
+    it('should pass line to messageHandler if registered', async () => {
+        const messageHandler = jest.fn();
+        plugin.onMessage(messageHandler);
+        plugin.startInteractiveInput();
+        const lineHandler = mockReadlineInterface.on.mock.calls.find(call => call[0] === 'line')[1];
+        await lineHandler('interactive input line');
+        expect(messageHandler).toHaveBeenCalledWith('interactive input line');
+        expect(mockReadlineInterface.prompt).toHaveBeenCalledTimes(2); // Initial + after line
+    });
+  });
+
+
+  describe('ITransport Methods', () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    beforeEach(async () => {
+      consoleSpy.mockClear();
+      await plugin.initialize(defaultConfig);
+    });
+
+    it('send() should print string message to console', async () => {
+      await plugin.send('Test output');
+      expect(consoleSpy).toHaveBeenCalledWith('Test output');
+    });
+    
+    it('send() should JSON.stringify object messages', async () => {
+        const message = { data: 'test', value: 123 };
+        await plugin.send(message);
+        expect(consoleSpy).toHaveBeenCalledWith(JSON.stringify(message, null, 2));
+    });
+
+    it('onMessage() should register a message handler', () => {
+      const handler = jest.fn();
+      plugin.onMessage(handler);
+      // @ts-ignore
+      expect(plugin['messageHandler']).toBe(handler);
+      expect(Logger.info).toHaveBeenCalledWith(expect.stringContaining('Generic message handler registered.'));
+    });
+
+    it('listen() should log and potentially start interactive input if configured', async () => {
+        const interactivePlugin = new StdioPlugin();
+        await interactivePlugin.initialize({ interactive: true });
+        const startInteractiveSpy = jest.spyOn(interactivePlugin, 'startInteractiveInput');
+        
+        // Calling listen() on its own might not trigger interactive mode based on current StdioPlugin logic.
+        // Interactive mode is primarily triggered by start() if no commands are given OR by explicit call to startInteractiveInput().
+        // The listen() method's comment says "If interactive mode is desired by default, it can be triggered here or in start()."
+        // The current implementation of listen() does not trigger it.
+        await interactivePlugin.listen(); 
+        expect(Logger.info).toHaveBeenCalledWith(expect.stringContaining('listen() called.'));
+        // Based on current implementation, listen() doesn't start interactive mode itself.
+        // If it were to, this spy would be called:
+        // expect(startInteractiveSpy).toHaveBeenCalled(); 
+    });
+    
+    it('close() should call stop', async () => {
+        const stopSpy = jest.spyOn(plugin, 'stop');
+        await plugin.close();
+        expect(stopSpy).toHaveBeenCalled();
+    });
+  });
+  
+  describe('Prompt Method', () => {
+    it('prompt() should call inquirer.prompt', async () => {
+        const questions = [{ type: 'input', name: 'testQ' }];
+        const answers = { testQ: 'testA' };
+        (inquirer.prompt as jest.Mock).mockResolvedValueOnce(answers);
+
+        const result = await plugin.prompt(questions as any);
+        expect(inquirer.prompt).toHaveBeenCalledWith(questions);
+        expect(result).toBe(answers);
+    });
+  });
+
+  describe('Cleanup', () => {
+    it('should log cleanup message and clear handlers', async () => {
+        await plugin.initialize(defaultConfig);
+        plugin.addCommandHandler('cmd', 'desc', {}, jest.fn());
+        // @ts-ignore
+        expect(plugin['commandHandlers'].size).toBeGreaterThan(0); // This is not how commands are stored in yargs
+
+        await plugin.cleanup();
+        // @ts-ignore
+        expect(plugin['yargsInstance']).toBeNull();
+        // @ts-ignore
+        expect(plugin['commandHandlers'].size).toBe(0); // This map is used internally before configuring yargs
+        expect(Logger.info).toHaveBeenCalledWith(expect.stringContaining('cleaned up.'));
+    });
+  });
+});

--- a/packages/plugin-websocket/README.md
+++ b/packages/plugin-websocket/README.md
@@ -1,56 +1,87 @@
 # MSA WebSocket Plugin (@arifwidianto/msa-plugin-websocket)
 
-This plugin provides a WebSocket server transport for the MSA (Microservice Architecture) framework. It uses the `ws` library to create and manage a WebSocket server, enabling real-time, bidirectional communication between clients and the service.
+This plugin provides real-time, bidirectional communication capabilities for the MSA framework using WebSockets. Built on the `ws` library, it enables services to establish persistent connections with clients for efficient real-time data exchange.
 
 ## Features
 
-*   Starts and stops a standalone WebSocket server.
-*   Configurable port, host, and WebSocket path (e.g., `/ws`).
-*   Handles client connections, disconnections, and incoming messages.
-*   Broadcasts messages to all connected clients.
-*   Implements `IPlugin` and `ITransport` from `@arifwidianto/msa-core`.
+* Standalone WebSocket server with connection management
+* Real-time bidirectional communication
+* Configurable port, host, and path settings
+* Automatic client tracking and management
+* Broadcasting capability to all connected clients
+* Connection event handling (connect, disconnect, error)
+* Secure WebSocket support (WSS)
+* Full implementation of both `IPlugin` and `ITransport` interfaces
 
 ## Installation
 
-This plugin is typically used as part of an MSA framework monorepo. Ensure it's listed as a dependency in your service or application package. The necessary dependencies (`ws`, `@types/ws`) should be automatically managed if using Lerna or npm/yarn workspaces.
+```bash
+npm install @arifwidianto/msa-plugin-websocket @arifwidianto/msa-core
+```
+
+## Quick Start
+
+```typescript
+import { Service, Logger } from '@arifwidianto/msa-core';
+import { WebSocketPlugin } from '@arifwidianto/msa-plugin-websocket';
+
+async function main() {
+  const service = new Service();
+  const wsPlugin = new WebSocketPlugin();
+  
+  service.registerPlugin(wsPlugin);
+  
+  await service.initializeService({
+    'msa-plugin-websocket': {
+      port: 8080,
+      path: '/ws'
+    }
+  });
+  
+  // Set up message handler before starting
+  wsPlugin.onMessage((message) => {
+    Logger.info(`Received WebSocket message: ${message}`);
+    
+    // Echo the message back with a timestamp
+    const response = {
+      type: 'echo',
+      originalMessage: message,
+      timestamp: new Date().toISOString()
+    };
+    
+    // Broadcast to all clients
+    wsPlugin.send(JSON.stringify(response));
+  });
+  
+  await service.startService();
+  Logger.info('WebSocket server started on ws://localhost:8080/ws');
+}
+
+main().catch(console.error);
+```
 
 ## Configuration
 
-The `WebSocketPlugin` can be configured during the service initialization phase. The configuration is passed to its `initialize` method.
-
-### `WebSocketPluginConfig`
+The WebSocket Plugin can be configured with the following options:
 
 ```typescript
-import { PluginConfig } from '@arifwidianto/msa-core';
-
-export interface WebSocketPluginConfig extends PluginConfig {
-  port: number;      // Required: The port number for the WebSocket server to listen on.
-  host?: string;    // Optional: The host address (e.g., '0.0.0.0' or 'localhost'). Defaults to 'localhost'.
-  path?: string;    // Optional: The WebSocket path (e.g., '/ws', '/api/socket'). Defaults to the root path '/'.
+interface WebSocketPluginConfig {
+  port: number;      // Required: The port number for the WebSocket server
+  host?: string;     // Optional: The host address (e.g., '0.0.0.0' or 'localhost')
+  path?: string;     // Optional: The WebSocket path (e.g., '/ws', '/socket')
 }
 ```
 
 ### Example Configuration
 
 ```typescript
-// In your main service setup
-import { Service } from '@arifwidianto/msa-core';
-import { WebSocketPlugin, WebSocketPluginConfig } from '@arifwidianto/msa-plugin-websocket';
-
-const service = new Service();
-const wsPlugin = new WebSocketPlugin();
-
-const pluginConfigs = {
+{
   'msa-plugin-websocket': {
-    port: 8081, // Separate port from HTTP if both are used
-    host: '0.0.0.0',
-    path: '/realtime'
-  } as WebSocketPluginConfig
-};
-
-service.registerPlugin(wsPlugin);
-await service.initializeService(pluginConfigs);
-await service.startService();
+    port: 8080,           // Listen on port 8080
+    host: '0.0.0.0',      // Listen on all network interfaces
+    path: '/realtime'     // WebSocket path: ws://hostname:8080/realtime
+  }
+}
 ```
 
 ## Basic Usage
@@ -99,11 +130,144 @@ if (wssInstance) {
 }
 ```
 
-## ITransport Implementation Notes
+## API Reference
 
-*   `listen(portOrPath)`: Configures the port the server will use when `start()` is called. The server runs on its own dedicated port.
-*   `send(message)`: Broadcasts the message to all connected clients.
-*   `onMessage(handler)`: Registers a handler for incoming messages from any client.
-*   `close()`: Equivalent to `stop()`, it closes the server and disconnects all clients.
+### send(message)
 
-This plugin provides the foundational server-side WebSocket capabilities. Client-specific message routing or session management would typically be built on top of this transport layer.
+Send a message to all connected WebSocket clients:
+
+```typescript
+// Broadcast a simple string
+wsPlugin.send('Hello, all connected clients!');
+
+// Broadcast a JSON object (automatically stringified)
+wsPlugin.send(JSON.stringify({
+  type: 'update',
+  data: {
+    value: 42,
+    message: 'New data available'
+  }
+}));
+```
+
+### onMessage(handler)
+
+Register a handler for incoming WebSocket messages:
+
+```typescript
+wsPlugin.onMessage((message) => {
+  try {
+    // Parse message if it's JSON
+    const data = JSON.parse(message.toString());
+    
+    // Process the message
+    if (data.type === 'request') {
+      // Handle request
+    }
+  } catch (error) {
+    // Handle parsing error
+    Logger.error(`Error processing message: ${error.message}`);
+  }
+});
+```
+
+### getWebSocketServer()
+
+Access the underlying `ws.WebSocketServer` instance for advanced configuration:
+
+```typescript
+const wss = wsPlugin.getWebSocketServer();
+if (wss) {
+  // Access the set of connected clients
+  const clientCount = wss.clients.size;
+  Logger.info(`Current connected clients: ${clientCount}`);
+  
+  // Set up custom event handlers
+  wss.on('headers', (headers, request) => {
+    // Add custom headers before upgrading
+    headers.push('X-Custom-Header: Value');
+  });
+}
+```
+
+## Browser Client Example
+
+Here's an example of how to connect to the WebSocket server from a browser client:
+
+```javascript
+// Connect to the WebSocket server
+const socket = new WebSocket('ws://localhost:8080/ws');
+
+// Set up event handlers
+socket.addEventListener('open', (event) => {
+  console.log('Connected to WebSocket server');
+  
+  // Send a message to the server
+  socket.send(JSON.stringify({
+    type: 'greeting',
+    message: 'Hello from browser client!'
+  }));
+});
+
+socket.addEventListener('message', (event) => {
+  try {
+    const data = JSON.parse(event.data);
+    console.log('Received message:', data);
+    
+    // Handle different message types
+    if (data.type === 'echo') {
+      console.log('Server echoed:', data.originalMessage);
+    }
+  } catch (error) {
+    console.error('Failed to parse message:', error);
+    console.log('Raw message:', event.data);
+  }
+});
+
+socket.addEventListener('close', (event) => {
+  console.log('Connection closed:', event.code, event.reason);
+});
+
+socket.addEventListener('error', (error) => {
+  console.error('WebSocket error:', error);
+});
+```
+
+## Node.js Client Example
+
+For Node.js clients, you can use the same `ws` library:
+
+```typescript
+import WebSocket from 'ws';
+
+const client = new WebSocket('ws://localhost:8080/ws');
+
+client.on('open', () => {
+  console.log('Connected to server');
+  client.send(JSON.stringify({ type: 'hello', message: 'Hello from Node.js client!' }));
+});
+
+client.on('message', (data) => {
+  console.log('Received:', data.toString());
+});
+
+client.on('close', (code, reason) => {
+  console.log(`Connection closed: ${code} - ${reason}`);
+});
+```
+
+## Development
+
+```bash
+# Install dependencies
+npm install
+
+# Build the package
+npm run build
+
+# Run tests
+npm run test
+
+# Development mode with watch
+npm run dev
+```

--- a/packages/plugin-websocket/jest.config.js
+++ b/packages/plugin-websocket/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  displayName: 'plugin-websocket',
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/test/**/*.test.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.json'
+    }
+  },
+  moduleNameMapper: {
+    '^@arifwidianto/msa-core$': '<rootDir>/../core/src/index.ts'
+  }
+};

--- a/packages/plugin-websocket/package.json
+++ b/packages/plugin-websocket/package.json
@@ -3,12 +3,27 @@
   "version": "0.1.0",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc -p tsconfig.build.json"
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rimraf dist",
+    "dev": "tsc -p tsconfig.build.json --watch",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage",
+    "lint": "eslint src/**/*.ts",
+    "prepublishOnly": "npm run build"
   },
   "devDependencies": {
     "typescript": "^5.4.5",
     "@arifwidianto/msa-core": "0.1.0",
-    "@types/ws": "^8.5.10"
+    "@types/ws": "^8.5.10",
+    "rimraf": "^5.0.5",
+    "jest": "^29.7.0",
+    "@types/jest": "^29.5.12",
+    "eslint": "^8.52.0",
+    "@typescript-eslint/eslint-plugin": "^6.9.1",
+    "@typescript-eslint/parser": "^6.9.1",
+    "ts-jest": "^29.1.2",
+    "mock-socket": "^9.3.1"
   },
   "peerDependencies": {
     "@arifwidianto/msa-core": "0.1.0"

--- a/packages/plugin-websocket/test/WebSocketPlugin.test.ts
+++ b/packages/plugin-websocket/test/WebSocketPlugin.test.ts
@@ -1,0 +1,257 @@
+import { WebSocketPlugin, WebSocketPluginConfig } from '../src';
+import { Logger } from '@arifwidianto/msa-core';
+import { WebSocketServer, WebSocket } from 'ws';
+
+// Mock Logger from @arifwidianto/msa-core
+jest.mock('@arifwidianto/msa-core', () => {
+  const originalModule = jest.requireActual('@arifwidianto/msa-core');
+  return {
+    ...originalModule,
+    Logger: {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    },
+  };
+});
+
+// Mock 'ws' module
+const mockWebSocket = {
+  on: jest.fn(),
+  close: jest.fn(),
+  send: jest.fn(),
+  readyState: WebSocket.OPEN, // Simulate open state
+};
+const mockWebSocketServer = {
+  on: jest.fn(),
+  close: jest.fn(),
+  clients: new Set(),
+};
+jest.mock('ws', () => ({
+  WebSocketServer: jest.fn(() => mockWebSocketServer),
+  WebSocket: jest.fn(() => mockWebSocket), // If WebSocket class itself is instantiated
+}));
+
+
+describe('WebSocketPlugin', () => {
+  let plugin: WebSocketPlugin;
+  const defaultConfig: WebSocketPluginConfig = { port: 3001, host: 'localhost', path: '/ws' };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Reset clients set for each test
+    mockWebSocketServer.clients.clear();
+    // Reset WebSocketServer mock to return a fresh mock server instance for each test
+    (WebSocketServer as jest.Mock).mockImplementation(() => {
+        // Clear previous .on listeners from the shared mockWebSocketServer object
+        // This is important if the same mock object is reused across tests.
+        // However, since jest.clearAllMocks() is called, this might be redundant
+        // if the mock implementation itself doesn't retain state across calls.
+        // For safety, let's ensure 'on' is clean or use a new object.
+        mockWebSocketServer.on.mockReset(); 
+        mockWebSocketServer.close.mockReset();
+        return mockWebSocketServer;
+    });
+
+    plugin = new WebSocketPlugin();
+  });
+
+  describe('Initialization', () => {
+    it('should initialize with default config if none provided', async () => {
+      await plugin.initialize({}); // Plugin has internal default { port: 3001 }
+      expect(Logger.info).toHaveBeenCalledWith(expect.stringContaining('initialized with config: {"port":3001}'));
+    });
+
+    it('should initialize with provided config', async () => {
+      await plugin.initialize(defaultConfig);
+      expect(Logger.info).toHaveBeenCalledWith(expect.stringContaining(JSON.stringify(defaultConfig)));
+    });
+    
+    it('should throw error if port is not configured (e.g. explicitly set to 0 or undefined)', async () => {
+        await expect(plugin.initialize({ port: 0 } as any)).rejects.toThrow('WebSocket Plugin: Port must be configured.');
+    });
+  });
+
+  describe('Start/Stop', () => {
+    beforeEach(async () => {
+      await plugin.initialize(defaultConfig);
+    });
+
+    it('should start the WebSocket server', async () => {
+      // Simulate 'listening' event being emitted
+      (WebSocketServer as jest.Mock).mockImplementationOnce(() => {
+        // Simulate 'listening' event
+        process.nextTick(() => {
+          const listeningCallback = mockWebSocketServer.on.mock.calls.find(call => call[0] === 'listening')?.[1];
+          if (listeningCallback) listeningCallback();
+        });
+        return mockWebSocketServer;
+      });
+
+      await plugin.start();
+      expect(WebSocketServer).toHaveBeenCalledWith({
+        port: defaultConfig.port,
+        host: defaultConfig.host,
+        path: defaultConfig.path,
+      });
+      expect(Logger.info).toHaveBeenCalledWith(expect.stringContaining(`Listening on ws://${defaultConfig.host}:${defaultConfig.port}${defaultConfig.path}`));
+    });
+    
+    it('should handle server error on start', async () => {
+        const error = new Error('Server start failed');
+        (WebSocketServer as jest.Mock).mockImplementationOnce(() => {
+            process.nextTick(() => {
+                 const errorCallback = mockWebSocketServer.on.mock.calls.find(call => call[0] === 'error')?.[1];
+                 if(errorCallback) errorCallback(error);
+            });
+            return mockWebSocketServer;
+        });
+        await expect(plugin.start()).rejects.toThrow(error.message);
+        expect(Logger.error).toHaveBeenCalledWith(expect.stringContaining(`failed to start or encountered a server error: ${error.message}`));
+    });
+
+    it('should stop the WebSocket server and close clients', async () => {
+      // Simulate a client being connected
+      const clientMock = { ...mockWebSocket, readyState: WebSocket.OPEN, close: jest.fn() };
+      mockWebSocketServer.clients.add(clientMock as any);
+
+      await plugin.start(); // Start first
+      (mockWebSocketServer.close as jest.Mock).mockImplementationOnce((callback) => callback()); // Simulate server closing
+
+      await plugin.stop();
+      expect(clientMock.close).toHaveBeenCalledWith(1000, 'Server shutting down');
+      expect(mockWebSocketServer.close).toHaveBeenCalled();
+      expect(Logger.info).toHaveBeenCalledWith(expect.stringContaining('stopped.'));
+      expect(mockWebSocketServer.clients.size).toBe(0);
+    });
+    
+    it('should resolve if stop is called when server is not running', async () => {
+        await plugin.stop();
+        expect(Logger.info).toHaveBeenCalledWith(expect.stringContaining('was not running.'));
+        expect(mockWebSocketServer.close).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Message Handling', () => {
+    let connectionCallback: ((ws: any) => void) | undefined;
+    let clientMessageCallback: ((data: string) => void) | undefined;
+
+    beforeEach(async () => {
+      await plugin.initialize(defaultConfig);
+      // Capture the 'connection' event handler
+      (WebSocketServer as jest.Mock).mockImplementationOnce(() => {
+        mockWebSocketServer.on = jest.fn((event, cb) => {
+          if (event === 'connection') {
+            connectionCallback = cb;
+          }
+        });
+        return mockWebSocketServer;
+      });
+      await plugin.start(); // This will set up the WSS and its event handlers
+    });
+
+    it('should register a message handler via onMessage', () => {
+      const handler = jest.fn();
+      plugin.onMessage(handler);
+      // @ts-ignore
+      expect(plugin['messageHandler']).toBe(handler);
+      expect(Logger.info).toHaveBeenCalledWith('WebSocket Plugin: Message handler registered via ITransport.onMessage().');
+    });
+
+    it('should handle incoming client messages if handler is registered', () => {
+      const messageHandler = jest.fn();
+      plugin.onMessage(messageHandler);
+
+      // Simulate a client connecting
+      const clientWsMock = { 
+        on: jest.fn((event, cb) => {
+          if (event === 'message') clientMessageCallback = cb;
+        }),
+        send: jest.fn(),
+        close: jest.fn(),
+        readyState: WebSocket.OPEN,
+      };
+      if (connectionCallback) {
+        connectionCallback(clientWsMock); // Simulate connection
+      } else {
+        throw new Error("Connection callback not captured");
+      }
+      
+      // Simulate client sending a message
+      const testMessage = 'hello server';
+      if (clientMessageCallback) {
+        clientMessageCallback(testMessage);
+      } else {
+        throw new Error("Client message callback not captured");
+      }
+      expect(messageHandler).toHaveBeenCalledWith(testMessage);
+      expect(Logger.debug).toHaveBeenCalledWith(expect.stringContaining(`Received message: ${testMessage}`));
+    });
+  });
+
+  describe('Send Method', () => {
+    beforeEach(async () => {
+      await plugin.initialize(defaultConfig);
+      await plugin.start();
+    });
+
+    it('should broadcast message to all open clients', async () => {
+      const client1Mock = { ...mockWebSocket, readyState: WebSocket.OPEN, send: jest.fn() };
+      const client2Mock = { ...mockWebSocket, readyState: WebSocket.OPEN, send: jest.fn() };
+      const client3Mock = { ...mockWebSocket, readyState: WebSocket.CLOSED, send: jest.fn() }; // Closed client
+
+      mockWebSocketServer.clients.add(client1Mock as any);
+      mockWebSocketServer.clients.add(client2Mock as any);
+      mockWebSocketServer.clients.add(client3Mock as any);
+
+      const message = 'broadcast test';
+      await plugin.send(message);
+
+      expect(client1Mock.send).toHaveBeenCalledWith(message);
+      expect(client2Mock.send).toHaveBeenCalledWith(message);
+      expect(client3Mock.send).not.toHaveBeenCalled();
+      expect(Logger.info).toHaveBeenCalledWith(expect.stringContaining('Message broadcasted to 2 clients.'));
+    });
+
+    it('should log if no clients are connected when sending', async () => {
+        const message = 'no one to send to';
+        await plugin.send(message);
+        expect(Logger.info).toHaveBeenCalledWith('WebSocket Plugin: No clients connected. Message not sent.');
+    });
+    
+    it('should reject if send is called when server not started', async () => {
+        const newPlugin = new WebSocketPlugin(); // Not started
+        await newPlugin.initialize(defaultConfig);
+        await expect(newPlugin.send("test")).rejects.toThrow('WebSocket server not running.');
+    });
+  });
+  
+  describe('ITransport methods consistency', () => {
+    it('listen() should configure port', async () => {
+        await plugin.listen(8999);
+        // @ts-ignore
+        expect(plugin['config'].port).toBe(8999);
+        await plugin.listen("9000");
+        // @ts-ignore
+        expect(plugin['config'].port).toBe(9000);
+        await plugin.listen("invalid_port_string");
+        // @ts-ignore
+        expect(plugin['config'].port).toBe(9000); // Should remain last valid
+        expect(Logger.warn).toHaveBeenCalledWith(expect.stringContaining("Invalid port for listen: invalid_port_string"));
+    });
+
+    it('close() should call stop', async () => {
+        const stopSpy = jest.spyOn(plugin, 'stop');
+        await plugin.close();
+        expect(stopSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('Cleanup', () => {
+    it('should log cleanup message', async () => {
+        await plugin.cleanup();
+        expect(Logger.info).toHaveBeenCalledWith(expect.stringContaining('cleaned up.'));
+    });
+  });
+});


### PR DESCRIPTION
This commit delivers the AI integration capabilities for the MSA Framework as outlined in Phase 2 of the development plan.

Includes:
- Langchain Integration Plugin (@arifwidianto/msa-plugin-langchain):
    - Integrates 'langchain' with '@langchain/openai' for LLM interactions.
    - Provides `invokeChain` for prompt-based execution and `chat` for conversational AI.
    - Includes configuration for API keys and model selection.
    - Unit tests and README documentation.

- MCP (Model Context Protocol) Plugin (@arifwidianto/msa-plugin-mcp):
    - Implements both client and server capabilities for MCP.
    - Defines MCP data structures (Request, Response, Context).
    - MCPClient for connecting to MCP servers via WebSockets, including request sending and response handling with auto-reconnection.
    - MCPServer for hosting MCP endpoints, using a configurable transport plugin (e.g., WebSocketPlugin) and allowing registration of action handlers.
    - Unit tests for client and server, and README documentation.

- Message Broker Plugin (@arifwidianto/msa-plugin-messagebroker) Enhancements:
    - Added Redis Pub/Sub integration alongside existing RabbitMQ support.
    - `RedisPubSubService` for managing Redis client connections and pub/sub logic.
    - Updated plugin configuration to select between 'rabbitmq' and 'redis'.
    - `ITransport` interface adapted for both message brokers.
    - Unit tests for Redis functionality and updated README.

- Integration Tests:
    - New `integration-tests` package.
    - Tests for `LangchainPlugin` interacting with a mocked LLM.
    - Client-server tests for `MCPPlugin` using `WebSocketPlugin` for transport, verifying request/response flow and error handling.

- Documentation for AI-Powered Services:
    - TypeDoc setup for API documentation generation.
    - Extensive TSDoc comments added to AI plugins.
    - Conceptual guides for building AI agents with `LangchainPlugin` and creating MCP-enabled services.
    - Main README for the `docs` directory.

Note: I encountered a persistent sandbox environment error (ENOENT: uv_cwd) that blocked automated execution of unit tests, integration tests, and TypeDoc documentation generation. However, all associated code, configurations, and documentation content have been implemented and are included in this commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced plugins for Langchain integration, MCP protocol (client/server), and message broker support (RabbitMQ and Redis Pub/Sub), each with comprehensive configuration options and lifecycle management.
  - Added detailed TypeScript interfaces and configuration schemas for new plugins and message protocols.
  - Enabled unified message transport and broker abstraction for microservice communication.
  - Enhanced HTTP plugin to support dynamic HTTP method registration without fixed whitelist validation.
- **Documentation**
  - Added extensive README files for Langchain, MCP, MessageBroker, HTTP, StdIO, WebSocket, and core packages, including setup guides, configuration, usage examples, and advanced scenarios.
  - Completely rewritten and expanded root README with detailed framework overview, package descriptions, installation, and examples.
- **Tests**
  - Added comprehensive test suites for all new plugins and services, covering initialization, lifecycle, message handling, error scenarios, and plugin-specific behaviors.
- **Chores**
  - Added Jest and TypeScript configuration files for all new packages to support testing and building in a monorepo structure.
  - Updated root and package-level configuration files to support multi-package management and testing.
  - Added new npm scripts for testing, building, linting, and development across packages.
  - Downgraded TypeScript version for compatibility and added necessary dev dependencies for Jest, ESLint, and testing utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->